### PR TITLE
fix(http): remove Host header from proxied requests

### DIFF
--- a/custom_components/scrypted/http.py
+++ b/custom_components/scrypted/http.py
@@ -279,6 +279,7 @@ def _init_header(request: web.Request) -> CIMultiDict | dict[str, str]:
             hdrs.SEC_WEBSOCKET_PROTOCOL,
             hdrs.SEC_WEBSOCKET_VERSION,
             hdrs.SEC_WEBSOCKET_KEY,
+            hdrs.HOST,
         ):
             continue
         headers[name] = value


### PR DESCRIPTION
In my setup, Home Assistant and Scrypted both are behind the same reverse proxy that use host-based routing (ingress-nginx in Kubernetes). 

Prior to this change the proxied requests were hitting the same reverse proxy but because the Host header wasn't stripped out from the browser -> Home Assistant sidebar view, the request just ended up back at Home Assistant, breaking the sidebar view. After this change the Host header is filtered out and requests are routed appropriately.