### PR TITLE
fix/async_forward_entry_setups

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -22,6 +22,11 @@ from .http import ScryptedView, retrieve_token
 
 from homeassistant.components import panel_custom, websocket_api
 
+
+PLATFORMS = [
+    Platform.SENSOR
+]
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Auth setup."""
     session = async_get_clientsession(hass, verify_ssl=False)
@@ -99,8 +104,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     )
 
     # Set up token sensor
-    await hass.config_entries.async_forward_entry_setup(
-        config_entry, Platform.SENSOR
+    await hass.config_entries.async_forward_entry_setups(
+        config_entry, PLATFORMS
     )
     return True
 

--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -99,9 +99,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     )
 
     # Set up token sensor
-    return await hass.config_entries.async_forward_entry_setup(
+    await hass.config_entries.async_forward_entry_setup(
         config_entry, Platform.SENSOR
     )
+    return True
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:


### PR DESCRIPTION
Problem:
1. `async_forward_entry_setup` is deprecated in favor of `async_forward_entry_setups`
2. `async_setup_entry` is expected to return a boolean indicating the result of setting up the configuration entry, however it is returning `None`

Solution:
1. Refactored to use `async_forward_entry_setups` following the accepted Home-Assistant integration pattern
2. Do not return the `None` result from the forward entry setup call, instead return `True` upon the completion of the coroutine.