### PR TITLE
Add frontend dependency to ensure proper initialization order

### DIFF
--- a/custom_components/scrypted/manifest.json
+++ b/custom_components/scrypted/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.10",
   "codeowners": ["@koush"],
   "config_flow": true,
-  "dependencies": ["http", "lovelace"],
+  "dependencies": ["http", "frontend"],
   "issue_tracker": "https://github.com/koush/ha_scrypted/issues",
   "documentation": "https://www.home-assistant.io/integrations/scrypted",
   "homekit": {},

--- a/custom_components/scrypted/manifest.json
+++ b/custom_components/scrypted/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.10",
   "codeowners": ["@koush"],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": ["http", "lovelace"],
   "issue_tracker": "https://github.com/koush/ha_scrypted/issues",
   "documentation": "https://www.home-assistant.io/integrations/scrypted",
   "homekit": {},


### PR DESCRIPTION
## Summary

Adds `frontend` to the integration's dependencies to ensure frontend and Lovelace loads before Scrypted during Home Assistant startup.

This avoids potential timing conflicts with the auto-register Lovelace resources feature. Without this dependency, if Scrypted loads before Lovelace, the resources collection may not be available yet, which could cause issues with resource registration/unregistration.

## Changes

- Added `frontend` to `dependencies` in `manifest.json`

## Test Plan

- [x] Verify integration loads successfully after HA restart
- [x] Verify auto-register resources feature works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)