### PR TITLE
Fix duplicate config entry collisions

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -40,6 +40,9 @@ _OPTION_DEFAULTS = {
 }
 
 
+ScryptedRuntimeState = dict[str, Any]
+
+
 def _get_card_resource_definitions(token: str) -> list[tuple[str, str]]:
     """Return the Lovelace resources that power the Scrypted cards."""
     base_url = f"/api/{DOMAIN}/{token}/endpoint/@scrypted/nvr/assets/web-components"
@@ -239,7 +242,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             raise ConfigEntryNotReady("ClientConnectorError. Is the Scrypted host down? Retrying.")
         raise e
 
-    hass.data.setdefault(DOMAIN, {})[token] = config_entry
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {
+        "entry": config_entry,
+        "token": token,
+    }
     config_entry.async_on_unload(
         config_entry.add_update_listener(_async_update_listener)
     )
@@ -251,7 +257,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         "name": "ha-panel-scrypted",
         # "embed_iframe": True,
         "trust_external": False,
-        "module_url": f"/api/{DOMAIN}/{token}/entrypoint.js",
+        "module_url": f"/api/{DOMAIN}/{config_entry.entry_id}/entrypoint.js",
     }
 
     panelconf = {}
@@ -263,7 +269,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         "custom",
         sidebar_title=config_entry.data[CONF_NAME],
         sidebar_icon=config_entry.data[CONF_ICON],
-        frontend_url_path=f"{DOMAIN}_{token}",
+        frontend_url_path=f"{DOMAIN}_{config_entry.entry_id}",
         config=panelconf,
         require_admin=False,
     )
@@ -277,18 +283,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    token = next(
-        token
-        for token, entry in hass.data[DOMAIN].items()
-        if entry.entry_id == config_entry.entry_id
-    )
+    state: ScryptedRuntimeState = hass.data[DOMAIN][config_entry.entry_id]
+    token = state["token"]
 
     await _async_unregister_lovelace_resource(hass, token, config_entry.entry_id)
 
-    hass.data[DOMAIN].pop(token)
+    hass.data[DOMAIN].pop(config_entry.entry_id)
     if not hass.data[DOMAIN]:
         hass.data.pop(DOMAIN)
-    async_remove_panel(hass, f"{DOMAIN}_{token}")
+    async_remove_panel(hass, f"{DOMAIN}_{config_entry.entry_id}")
     return True
 
 

--- a/custom_components/scrypted/http.py
+++ b/custom_components/scrypted/http.py
@@ -55,7 +55,7 @@ class ScryptedView(HomeAssistantView):
     """Hass.io view to handle base part."""
 
     name = "api:scrypted"
-    url = "/api/scrypted/{token}/{path:.*}"
+    url = "/api/scrypted/{identifier}/{path:.*}"
     requires_auth = False
 
     def __init__(self, hass: HomeAssistant, session: aiohttp.ClientSession) -> None:
@@ -75,10 +75,26 @@ class ScryptedView(HomeAssistantView):
         loop.call_soon_threadsafe(lambda: self.entrypoint_js.set_result(entrypoint_js))
         loop.call_soon_threadsafe(lambda: self.entrypoint_html.set_result(entrypoint_html))
 
+    def _get_state(self, identifier: str) -> dict[str, Any]:
+        """Resolve a route identifier to runtime state.
+
+        We key active state by config entry ID to avoid collisions when two
+        entries talk to the same Scrypted backend and receive the same token.
+        Older token-based routes are still accepted for compatibility.
+        """
+        if state := self.hass.data[DOMAIN].get(identifier):
+            return state
+
+        for state in self.hass.data[DOMAIN].values():
+            if state["token"] == identifier:
+                return state
+
+        raise KeyError(identifier)
+
     @lru_cache
-    def _create_url(self, token: str, path: str) -> str:
+    def _create_url(self, identifier: str, path: str) -> str:
         """Create URL to service."""
-        entry: ConfigEntry = self.hass.data[DOMAIN][token]
+        entry: ConfigEntry = self._get_state(identifier)["entry"]
         host = entry.data[CONF_HOST]
         ipport = host.split(":")
         if len(ipport) > 2:
@@ -101,7 +117,7 @@ class ScryptedView(HomeAssistantView):
         return url
 
     async def _handle(
-        self, request: web.Request, token: str, path: str
+        self, request: web.Request, identifier: str, path: str
     ) -> web.Response | web.StreamResponse | web.WebSocketResponse:
         """Route data to Hass.io ingress service."""
         try:
@@ -116,7 +132,7 @@ class ScryptedView(HomeAssistantView):
                 return response
 
             if path == "entrypoint.js":
-                body = (await self.entrypoint_js).replace("__DOMAIN__", DOMAIN).replace("__TOKEN__", token)
+                body = (await self.entrypoint_js).replace("__DOMAIN__", DOMAIN).replace("__TOKEN__", identifier)
                 response = web.Response(
                     body=body,
                     headers={
@@ -127,8 +143,8 @@ class ScryptedView(HomeAssistantView):
                 return response
 
             if path == "entrypoint.html":
-                body = (await self.entrypoint_html).replace("__DOMAIN__", DOMAIN).replace("__TOKEN__", token)
-                entry: ConfigEntry = self.hass.data[DOMAIN][token]
+                body = (await self.entrypoint_html).replace("__DOMAIN__", DOMAIN).replace("__TOKEN__", identifier)
+                entry: ConfigEntry = self._get_state(identifier)["entry"]
                 if entry.options.get(CONF_SCRYPTED_NVR, entry.data.get(CONF_SCRYPTED_NVR, False)):
                     body = body.replace("core", "nvr")
 
@@ -143,12 +159,12 @@ class ScryptedView(HomeAssistantView):
 
             # Websocket
             if _is_websocket(request):
-                return await self._handle_websocket(request, token, path)
+                return await self._handle_websocket(request, identifier, path)
 
             # Request
-            return await self._handle_request(request, token, path)
+            return await self._handle_request(request, identifier, path)
 
-        except aiohttp.ClientError as err:
+        except (aiohttp.ClientError, KeyError) as err:
             _LOGGER.debug("Ingress error with %s: %s", path, err)
 
         raise HTTPBadGateway() from None
@@ -161,7 +177,7 @@ class ScryptedView(HomeAssistantView):
     # options = _handle
 
     async def _handle_websocket(
-        self, request: web.Request, token: str, path: str
+        self, request: web.Request, identifier: str, path: str
     ) -> web.WebSocketResponse:
         """Ingress route for websocket."""
         req_protocols: Iterable[str]
@@ -179,7 +195,9 @@ class ScryptedView(HomeAssistantView):
         await ws_server.prepare(request)
 
         # Preparing
-        url = self._create_url(token, path)
+        state = self._get_state(identifier)
+        token = state["token"]
+        url = self._create_url(identifier, path)
         source_header = _init_header(request)
         source_header["Authorization"] = f"Bearer {token}"
 
@@ -209,10 +227,12 @@ class ScryptedView(HomeAssistantView):
         return ws_server
 
     async def _handle_request(
-        self, request: web.Request, token: str, path: str
+        self, request: web.Request, identifier: str, path: str
     ) -> web.Response | web.StreamResponse:
         """Ingress route for request."""
-        url = self._create_url(token, path)
+        state = self._get_state(identifier)
+        token = state["token"]
+        url = self._create_url(identifier, path)
         source_header = _init_header(request)
         source_header["Authorization"] = f"Bearer {token}"
 

--- a/custom_components/scrypted/sensor.py
+++ b/custom_components/scrypted/sensor.py
@@ -15,11 +15,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Scrypted token sensor from config entry."""
-    token = next(
-        token
-        for token, entry in hass.data[DOMAIN].items()
-        if entry.entry_id == config_entry.entry_id
-    )
+    token = hass.data[DOMAIN][config_entry.entry_id]["token"]
     async_add_entities([ScryptedTokenSensor(config_entry, token)])
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,63 @@
+"""Tests for the Scrypted HTTP proxy view."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.const import CONF_HOST
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.scrypted.const import DOMAIN
+from custom_components.scrypted.http import ScryptedView
+
+
+def _build_view(hass) -> ScryptedView:
+    """Create a ScryptedView with a dummy session."""
+    return ScryptedView(hass, SimpleNamespace(loop=hass.loop))
+
+
+@pytest.mark.asyncio
+async def test_get_state_accepts_entry_id_and_legacy_token(hass):
+    """Runtime state can be resolved by entry ID and legacy token route."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "example"})
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "entry": entry,
+        "token": "token",
+    }
+
+    view = _build_view(hass)
+
+    assert view._get_state(entry.entry_id)["entry"] == entry
+    assert view._get_state("token")["entry"] == entry
+
+
+@pytest.mark.asyncio
+async def test_entrypoint_uses_requested_identifier(hass):
+    """The entrypoint keeps using whichever route identifier was requested."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "example"})
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "entry": entry,
+        "token": "token",
+    }
+
+    view = _build_view(hass)
+    response = await view._handle(SimpleNamespace(), entry.entry_id, "entrypoint.js")
+    body = response.body.decode()
+
+    assert f"/api/{DOMAIN}/{entry.entry_id}/entrypoint.html" in body
+
+
+@pytest.mark.asyncio
+async def test_create_url_uses_entry_state_for_host(hass):
+    """URL creation resolves the backend host from the entry ID state."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "1.2.3.4:10443"})
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "entry": entry,
+        "token": "token",
+    }
+
+    view = _build_view(hass)
+
+    assert view._create_url(entry.entry_id, "endpoint/foo") == "https://1.2.3.4:10443/endpoint/foo"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -257,7 +257,8 @@ async def test_async_setup_entry_registers_resources_and_panel(hass, monkeypatch
     assert result is True
     register_resource.assert_awaited()
     forward_setups.assert_awaited()
-    assert hass.data[DOMAIN]["token"] == entry
+    assert hass.data[DOMAIN][entry.entry_id]["entry"] == entry
+    assert hass.data[DOMAIN][entry.entry_id]["token"] == "token"
     assert entry.options[CONF_SCRYPTED_NVR] is False
     assert CONF_SCRYPTED_NVR not in entry.data
     assert not reload_mock.called
@@ -474,7 +475,10 @@ async def test_async_unload_entry(hass, monkeypatch):
         },
     )
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})["token"] = entry
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "entry": entry,
+        "token": "token",
+    }
     hass.data.setdefault(scrypted._RESOURCE_TRACKER, {})[entry.entry_id] = set()
     unregister = AsyncMock()
     monkeypatch.setattr(scrypted, "_async_unregister_lovelace_resource", unregister)
@@ -488,8 +492,8 @@ async def test_async_unload_entry(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_panel_registered_with_token(hass, monkeypatch):
-    """Test that panel is registered using token in the URL path."""
+async def test_panel_registered_with_entry_id(hass, monkeypatch):
+    """Test that panel is registered using the config entry ID in the URL path."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -513,12 +517,15 @@ async def test_panel_registered_with_token(hass, monkeypatch):
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
     result = await scrypted.async_setup_entry(hass, entry)
     assert result is True
-    assert panel_kwargs["frontend_url_path"] == f"{DOMAIN}_token"
+    assert panel_kwargs["frontend_url_path"] == f"{DOMAIN}_{entry.entry_id}"
+    assert panel_kwargs["config"]["_panel_custom"]["module_url"] == (
+        f"/api/{DOMAIN}/{entry.entry_id}/entrypoint.js"
+    )
 
 
 @pytest.mark.asyncio
-async def test_panel_unregistered_with_token(hass, monkeypatch):
-    """Test that panel is unregistered using the same token-based URL path."""
+async def test_panel_unregistered_with_entry_id(hass, monkeypatch):
+    """Test that panel is unregistered using the same entry-id URL path."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -529,7 +536,10 @@ async def test_panel_unregistered_with_token(hass, monkeypatch):
         },
     )
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})["token"] = entry
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "entry": entry,
+        "token": "token",
+    }
     unregister = AsyncMock()
     monkeypatch.setattr(scrypted, "_async_unregister_lovelace_resource", unregister)
     removed_panels = []
@@ -540,7 +550,7 @@ async def test_panel_unregistered_with_token(hass, monkeypatch):
     )
     result = await scrypted.async_unload_entry(hass, entry)
     assert result is True
-    assert removed_panels == [f"{DOMAIN}_token"]
+    assert removed_panels == [f"{DOMAIN}_{entry.entry_id}"]
 
 
 @pytest.mark.asyncio
@@ -548,7 +558,7 @@ async def test_panel_reload_uses_consistent_url_path(hass, monkeypatch):
     """Test that panel can be reloaded without 'Overwriting panel' errors.
 
     This verifies that both registration and unregistration use the same
-    token-based URL path, allowing clean reloads.
+    entry-id URL path, allowing clean reloads.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -587,17 +597,72 @@ async def test_panel_reload_uses_consistent_url_path(hass, monkeypatch):
     # First setup
     result = await scrypted.async_setup_entry(hass, entry)
     assert result is True
-    assert f"{DOMAIN}_token" in registered_panels
+    assert f"{DOMAIN}_{entry.entry_id}" in registered_panels
 
     # Unload
     result = await scrypted.async_unload_entry(hass, entry)
     assert result is True
-    assert f"{DOMAIN}_token" not in registered_panels
+    assert f"{DOMAIN}_{entry.entry_id}" not in registered_panels
 
-    # Re-add token mapping for second setup
+    # Re-add domain mapping for second setup
     hass.data.setdefault(DOMAIN, {})
 
     # Second setup (simulating reload) - should not raise ValueError
     result = await scrypted.async_setup_entry(hass, entry)
     assert result is True
-    assert f"{DOMAIN}_token" in registered_panels
+    assert f"{DOMAIN}_{entry.entry_id}" in registered_panels
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_same_token_keeps_entries_isolated(hass, monkeypatch):
+    """Two entries can coexist even when Scrypted returns the same token."""
+    entry_one = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "example",
+            CONF_ICON: "mdi:test",
+            CONF_NAME: "Scrypted One",
+            CONF_USERNAME: "user",
+        },
+        options={
+            CONF_AUTO_REGISTER_RESOURCES: False,
+            CONF_SCRYPTED_NVR: False,
+        },
+    )
+    entry_two = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "example-two",
+            CONF_ICON: "mdi:test",
+            CONF_NAME: "Scrypted Two",
+            CONF_USERNAME: "user",
+        },
+        options={
+            CONF_AUTO_REGISTER_RESOURCES: False,
+            CONF_SCRYPTED_NVR: False,
+        },
+    )
+    entry_one.add_to_hass(hass)
+    entry_two.add_to_hass(hass)
+
+    registered_panels = []
+    monkeypatch.setattr(
+        scrypted,
+        "async_register_built_in_panel",
+        lambda *args, **kwargs: registered_panels.append(kwargs["frontend_url_path"]),
+    )
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
+
+    result = await scrypted.async_setup_entry(hass, entry_one)
+    assert result is True
+    result = await scrypted.async_setup_entry(hass, entry_two)
+    assert result is True
+
+    assert hass.data[DOMAIN][entry_one.entry_id]["entry"] == entry_one
+    assert hass.data[DOMAIN][entry_one.entry_id]["token"] == "token"
+    assert hass.data[DOMAIN][entry_two.entry_id]["entry"] == entry_two
+    assert hass.data[DOMAIN][entry_two.entry_id]["token"] == "token"
+    assert registered_panels == [
+        f"{DOMAIN}_{entry_one.entry_id}",
+        f"{DOMAIN}_{entry_two.entry_id}",
+    ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,7 +25,10 @@ async def test_async_setup_entry_adds_token_sensor(hass):
     """Test case for test_async_setup_entry_adds_token_sensor."""
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "example"})
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})["token"] = entry
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "entry": entry,
+        "token": "token",
+    }
     added = []
 
     def _add_entities(entities):


### PR DESCRIPTION
## Summary
- key active Scrypted runtime state by config entry ID instead of bearer token so duplicate entries do not overwrite each other
- switch panel and primary proxy routes to use the stable entry ID while preserving token-based route compatibility for existing URLs
- add regression coverage for duplicate entries sharing a token plus route compatibility checks

## Testing
- .venv/bin/pytest