### PR TITLE
fix: start reauth flow on auth failure (401/403) instead of erroring setup

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from aiohttp import ClientConnectorError
+from aiohttp import ClientConnectorError, ClientResponseError
 
 from homeassistant.components.frontend import (
     async_register_built_in_panel,
@@ -237,6 +237,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except Exception as e:
         if isinstance(e, ClientConnectorError):
             raise ConfigEntryNotReady("ClientConnectorError. Is the Scrypted host down? Retrying.")
+        if isinstance(e, ClientResponseError) and e.status in (401, 403):
+            _LOGGER.warning(
+                "Scrypted authentication failed (HTTP %s) for %s; starting reauth flow.",
+                e.status, config_entry.title,
+            )
+            return _reauth(config_entry.data)
         raise e
 
     hass.data.setdefault(DOMAIN, {})[token] = config_entry


### PR DESCRIPTION
## Summary

Trigger the existing reauth flow when the Scrypted server rejects the stored
credentials (HTTP 401/403), instead of failing config-entry setup with an
opaque traceback.

## Problem

`retrieve_token()` calls `GET /login` with `raise_for_status=True`, so an
authentication failure raises `aiohttp.ClientResponseError`. In
`async_setup_entry`, the `except` block only treats `ClientConnectorError`
(host unreachable) as retryable — everything else, including a 401/403, hits
`raise e`:

```python
except Exception as e:
    if isinstance(e, ClientConnectorError):
        raise ConfigEntryNotReady("ClientConnectorError. Is the Scrypted host down? Retrying.")
    raise e
```

The result is `Error setting up entry … for scrypted` with a full traceback and
a permanent error badge. The user has no actionable path — the integration
already ships a reauth flow (`_reauth()` → `async_step_reauth`), but it's only
reachable via the `if not (token := …): return _reauth(...)` branch, which can
never run because `raise_for_status=True` makes `retrieve_token` raise rather
than return a falsy value on a bad password.

This is the failure mode behind reports like #19 (setup fails despite the user
being certain the credentials are correct): a stale/incorrect password produces
a cryptic error rather than a re-authenticate prompt.

## Fix

Route a 401/403 `ClientResponseError` to the integration's existing
`_reauth(config_entry.data)` path:

```python
except Exception as e:
    if isinstance(e, ClientConnectorError):
        raise ConfigEntryNotReady("ClientConnectorError. Is the Scrypted host down? Retrying.")
    if isinstance(e, ClientResponseError) and e.status in (401, 403):
        _LOGGER.warning(
            "Scrypted authentication failed (HTTP %s) for %s; starting reauth flow.",
            e.status, config_entry.title,
        )
        return _reauth(config_entry.data)
    raise e
```

I used `_reauth()` rather than raising `homeassistant.exceptions.ConfigEntryAuthFailed`
because `async_step_reauth` reads `self.context["data"]`, which `_reauth`
populates (`"data": payload`). HA's generic auth-failed reauth start does not
set that key, so raising `ConfigEntryAuthFailed` as-is would `KeyError` in the
reauth step. Reusing `_reauth()` keeps the change minimal and consistent with
the flow the integration already implements. (Migrating to the more idiomatic
`ConfigEntryAuthFailed` would additionally require `async_step_reauth` to read
the entry data via `entry_id` instead of `context["data"]` — out of scope here.)

## Testing

On Home Assistant 2026.5.2 with this integration:

- **Wrong password:** entry no longer throws; log shows
  `Scrypted authentication failed (HTTP 401) … starting reauth flow`, and a
  reauth flow is started at the `credentials` step
  (`config_entries/flow/progress` → `handler: scrypted, source: reauth`) — i.e.
  the UI shows a "Reconfigure" prompt instead of an error badge.
- **Correct password restored:** entry returns to `state: loaded`, the reauth
  flow clears, and the token sensor is populated. No regression to the success
  path.

## Notes

Minimal, surgical change (1 import + 6 lines). No behavior change for the
host-unreachable (`ClientConnectorError` → retry) or success paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
