### PR TITLE
fix: panel renders as a black page on HA 2026.8 (zero-height custom panel)

### DIFF
--- a/custom_components/scrypted/entrypoint.js
+++ b/custom_components/scrypted/entrypoint.js
@@ -39,6 +39,15 @@ class ExamplePanel extends LitElement {
 
     static get styles() {
         return css`
+        :host {
+            /* HA 2026.8 stopped giving custom panel elements an implicit
+               height (partial-panel-resolver is now height:auto), so a
+               percentage chain collapses to a 0-height iframe. Size the
+               host against the viewport instead. */
+            display: block;
+            height: 100vh;
+            height: 100dvh;
+        }
         iframe {
             border: 0;
             width: 100%;


### PR DESCRIPTION
## Problem
On Home Assistant 2026.8 (currently in beta, stable expected ~Aug 6), the Scrypted panel renders as a black/blank page. The NVR web app inside the iframe actually loads and connects fine — but HA's frontend no longer gives custom panel elements an implicit height (`partial-panel-resolver` is now `height: auto`), so the panel's percentage-based height chain collapses and the iframe renders at 0px tall.

Debugged live against a 2026.8.0b2 instance: `ha-panel-scrypted` and its iframe both measure `height: 0`; setting an explicit viewport height on the host instantly renders the full UI.

## Fix
Give the `:host` an explicit `display: block; height: 100dvh` (with `100vh` fallback) in `entrypoint.js`, making the panel's size independent of the parent layout chain. Unaffected on older HA versions — the host previously stretched to the same viewport height.

Worth merging before 2026.8 stable lands — every user on the new frontend will hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)