### PR TITLE
feat: binary sensor platform for scrypted devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ cards.
 Visit the [Scrypted Documentation](https://docs.scrypted.app/home-assistant.html)
 for setup instructions.
 
+## Device entities
+
+When *Create entities for Scrypted devices* is enabled (default), the
+integration connects to the Scrypted server over its engine.io RPC API and
+creates entities for discovered devices. By default only **Camera** and
+**Doorbell** device types are mirrored; pick additional Scrypted device types
+in the integration options.
+
+- **Camera** — snapshots for `VideoCamera` devices. Live streaming is
+  intentionally not supported; use the Scrypted NVR cards for live view.
+- **Binary sensor** — motion, doorbell button, sound, occupancy, flood, entry,
+  power, connectivity, tamper, charging, sleeping.
+
+State updates are pushed; no polling. Entities reconnect automatically if the
+server restarts.
+
 ## Development
 
 ### Using Dev Container (Recommended)

--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -57,6 +57,7 @@ class ScryptedRuntimeData:
 
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.CAMERA,
     Platform.SENSOR,
 ]

--- a/custom_components/scrypted/binary_sensor.py
+++ b/custom_components/scrypted/binary_sensor.py
@@ -1,0 +1,151 @@
+"""Binary sensors for Scrypted device states."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedBinarySensorDescription(
+    BinarySensorEntityDescription, ScryptedEntityDescriptionMixin
+):
+    """Describes a scrypted binary sensor."""
+
+
+BINARY_SENSORS: tuple[ScryptedBinarySensorDescription, ...] = (
+    ScryptedBinarySensorDescription(
+        key="motion",
+        name="Motion",
+        interface="MotionSensor",
+        state_property="motionDetected",
+        device_class=BinarySensorDeviceClass.MOTION,
+    ),
+    ScryptedBinarySensorDescription(
+        key="binary_state",
+        name="Binary state",
+        interface="BinarySensor",
+        state_property="binaryState",
+    ),
+    ScryptedBinarySensorDescription(
+        key="audio",
+        name="Sound",
+        interface="AudioSensor",
+        state_property="audioDetected",
+        device_class=BinarySensorDeviceClass.SOUND,
+    ),
+    ScryptedBinarySensorDescription(
+        key="occupancy",
+        name="Occupancy",
+        interface="OccupancySensor",
+        state_property="occupied",
+        device_class=BinarySensorDeviceClass.OCCUPANCY,
+    ),
+    ScryptedBinarySensorDescription(
+        key="flooded",
+        name="Flooded",
+        interface="FloodSensor",
+        state_property="flooded",
+        device_class=BinarySensorDeviceClass.MOISTURE,
+    ),
+    ScryptedBinarySensorDescription(
+        key="entry_open",
+        name="Entry open",
+        interface="EntrySensor",
+        state_property="entryOpen",
+        device_class=BinarySensorDeviceClass.DOOR,
+        # entryOpen can be True/False/'jammed'
+        value_fn=lambda value: value is True,
+    ),
+    ScryptedBinarySensorDescription(
+        key="power",
+        name="Power",
+        interface="PowerSensor",
+        state_property="powerDetected",
+        device_class=BinarySensorDeviceClass.POWER,
+    ),
+    ScryptedBinarySensorDescription(
+        key="online",
+        name="Online",
+        interface="Online",
+        state_property="online",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ScryptedBinarySensorDescription(
+        key="tampered",
+        name="Tampered",
+        interface="TamperSensor",
+        state_property="tampered",
+        device_class=BinarySensorDeviceClass.TAMPER,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # tampered is a TamperState string or falsy
+        value_fn=bool,
+    ),
+    ScryptedBinarySensorDescription(
+        key="charging",
+        name="Charging",
+        interface="Charger",
+        state_property="chargeState",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value in ("charging", "trickle"),
+    ),
+    ScryptedBinarySensorDescription(
+        key="sleeping",
+        name="Sleeping",
+        interface="Sleep",
+        state_property="sleeping",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted binary sensors."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedBinarySensor]:
+        return [
+            ScryptedBinarySensor(client, config_entry, device_id, description)
+            for description in BINARY_SENSORS
+            if device_matches(client, device_id, description.interface)
+        ]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedBinarySensor(ScryptedDeviceEntity, BinarySensorEntity):
+    """A boolean scrypted device property."""
+
+    entity_description: ScryptedBinarySensorDescription
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the boolean state, or None while the property is unset."""
+        value = self.raw_value
+        if value is None:
+            return None
+        return bool(self.entity_description.value_fn(value))

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,101 @@
+"""Tests for scrypted binary sensors."""
+
+from types import SimpleNamespace
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from custom_components.scrypted.binary_sensor import (
+    BINARY_SENSORS,
+    ScryptedBinarySensor,
+)
+from custom_components.scrypted.const import (
+    DOMAIN,
+    SIGNAL_NEW_DEVICE,
+)
+from tests.conftest import setup_entry
+
+
+async def test_motion_sensor_created_and_updates(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Motion sensor created and updates."""
+    await setup_entry(hass)
+
+    state = hass.states.get("binary_sensor.porch_front_door_cam_motion")
+    assert state is not None
+    assert state.state == "off"
+
+    fake_sdk.systemManager.set_property("cam1", "motionDetected", True)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.porch_front_door_cam_motion").state == "on"
+
+
+async def test_flood_sensor_created(hass, fake_sdk, enable_custom_integrations):
+    """Flood sensor created."""
+    await setup_entry(hass)
+    state = hass.states.get("binary_sensor.basement_basement_leak_flooded")
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_excluded_plugin_has_no_entities(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Excluded plugin has no entities."""
+    await setup_entry(hass)
+    # plugin1 (type API) must not create a connectivity sensor
+    assert not [
+        s
+        for s in hass.states.async_all("binary_sensor")
+        if "some_plugin" in s.entity_id
+    ]
+
+
+async def test_new_device_added_at_runtime(hass, fake_sdk, enable_custom_integrations):
+    """New device added at runtime."""
+    await setup_entry(hass)
+    fake_sdk.systemManager.systemState["new1"] = {
+        "name": {"value": "Garage Leak"},
+        "type": {"value": "Sensor"},
+        "info": {"value": {}},
+        "interfaces": {"value": ["FloodSensor"]},
+    }
+    fake_sdk.systemManager.set_property("new1", "flooded", True)
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.garage_leak_flooded")
+    assert state is not None
+    assert state.state == "on"
+
+
+async def test_offline_device_unavailable(hass, fake_sdk, enable_custom_integrations):
+    """Offline device unavailable."""
+    await setup_entry(hass)
+    fake_sdk.systemManager.set_property("cam1", "online", False)
+    await hass.async_block_till_done()
+    assert (
+        hass.states.get("binary_sensor.porch_front_door_cam_motion").state
+        == "unavailable"
+    )
+
+
+async def test_new_device_signal_dedup(hass, fake_sdk, enable_custom_integrations):
+    """Re-announcing a known or unknown device creates no duplicate entities."""
+    entry = await setup_entry(hass)
+    before = len(hass.states.async_all())
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "cam1")
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "bell1")
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "ghost")
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == before
+
+
+def test_binary_sensor_is_on_none_when_property_missing(fake_sdk):
+    """Return None instead of a bool when the device property is unset."""
+    client = SimpleNamespace(sdk=fake_sdk, connected=True)
+    entry = MockConfigEntry(domain=DOMAIN)
+    description = next(d for d in BINARY_SENSORS if d.key == "motion")
+    entity = ScryptedBinarySensor(client, entry, "cam1", description)
+    fake_sdk.systemManager.systemState["cam1"].pop("motionDetected")
+    assert entity.is_on is None


### PR DESCRIPTION
## Summary

First of the platform PRs that follow the device-entities foundation (#47). Adds a `binary_sensor` platform that mirrors boolean scrypted device properties:

| Entity | Scrypted interface | Property |
|---|---|---|
| Motion | `MotionSensor` | `motionDetected` |
| Binary state (doorbell button) | `BinarySensor` | `binaryState` |
| Sound | `AudioSensor` | `audioDetected` |
| Occupancy | `OccupancySensor` | `occupied` |
| Flooded | `FloodSensor` | `flooded` |
| Entry open | `EntrySensor` | `entryOpen` |
| Power | `PowerSensor` | `powerDetected` |
| Online (diagnostic) | `Online` | `online` |
| Tampered (diagnostic) | `TamperSensor` | `tampered` |
| Charging (diagnostic) | `Charger` | `chargeState` |
| Sleeping (diagnostic) | `Sleep` | `sleeping` |

Discovery goes through the shared `async_setup_scrypted_platform` helper and the device-type allowlist from #47, so with the default options cameras and doorbells get motion and doorbell-button sensors and nothing else appears until more device types are enabled. State is pushed from scrypted events; there is no polling.

Also adds a "Device entities" section to the README covering the option, cameras and binary sensors.

## Series

Remaining platforms from the original device-entities branch (#43), in suggested merge order: binary sensors (this PR), events, device sensors, NVR clips media source, intercom media player, then the controllable device platforms. Each PR is independent against `main`; the only expected conflict between them is the one-line `PLATFORMS` list in `__init__.py`, which I will rebase as they land.

## Test plan

- [x] `pytest` — 120 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit
- [x] Verified live against a scrypted server in the original branch (#43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
