### PR TITLE
feat: event entities for scrypted object detection and doorbell presses

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -59,6 +59,7 @@ class ScryptedRuntimeData:
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.EVENT,
     Platform.SENSOR,
 ]
 

--- a/custom_components/scrypted/event.py
+++ b/custom_components/scrypted/event.py
@@ -1,0 +1,173 @@
+"""Event entities for stateless Scrypted events."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import SIGNAL_CONNECTION
+from .entity import ScryptedDeviceEntity, async_setup_scrypted_platform, device_matches
+
+_LOGGER = logging.getLogger(__name__)
+
+# scrypted reports motion as a detection class (its motion pipeline rides the
+# ObjectDetector interface); HA already exposes that signal via the motion
+# binary_sensor, so the event entity only handles classified objects.
+MOTION_CLASS = "motion"
+
+OBJECT_DETECTED = EventEntityDescription(
+    key="object_detected",
+    name="Object detected",
+    device_class=EventDeviceClass.MOTION,
+)
+DOORBELL = EventEntityDescription(
+    key="doorbell",
+    name="Doorbell",
+    device_class=EventDeviceClass.DOORBELL,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted event entities."""
+    client = config_entry.runtime_data.client
+
+    async def _discover(device_id: str) -> list[EventEntity]:
+        entities: list[EventEntity] = []
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None:
+            return entities
+        if device_matches(client, device_id, ScryptedInterface.ObjectDetector.value):
+            event_types = await _async_object_event_types(device)
+            if event_types:
+                entities.append(
+                    ScryptedObjectDetectionEvent(
+                        client, config_entry, device_id, OBJECT_DETECTED, event_types
+                    )
+                )
+        if device.type == "Doorbell" and device_matches(
+            client, device_id, ScryptedInterface.BinarySensor.value
+        ):
+            entities.append(
+                ScryptedDoorbellEvent(client, config_entry, device_id, DOORBELL)
+            )
+        return entities
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+async def _async_object_event_types(device) -> list[str]:
+    """Return the detection classes the device reports, minus scrypted's motion class."""
+    try:
+        object_types = await device.getObjectTypes()
+        classes = list((object_types or {}).get("classes") or [])
+    except Exception:  # noqa: BLE001 - some detectors don't implement this
+        _LOGGER.debug("getObjectTypes failed for %s", device.id, exc_info=True)
+        classes = []
+    return [name for name in classes if name != MOTION_CLASS]
+
+
+class ScryptedObjectDetectionEvent(ScryptedDeviceEntity, EventEntity):
+    """Fires when the scrypted ObjectDetector reports detections.
+
+    Stateless ObjectsDetected payloads do not reach system listeners, so this
+    entity owns a per-device server-side subscription (listenDevice) and must
+    re-register it after every reconnect.
+    """
+
+    def __init__(self, client, entry, device_id, description, event_types) -> None:
+        """Initialize the object detection event entity."""
+        super().__init__(client, entry, device_id, description)
+        self._attr_event_types: list[str] = event_types
+        self._unregister = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register the detection listener and re-register it after reconnects."""
+        await super().async_added_to_hass()
+        self._register_listener()
+        # Re-register the server-side listener after reconnects.
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_CONNECTION.format(self.entry.entry_id),
+                self._handle_reconnect,
+            )
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the server-side detection listener."""
+        self._remove_listener()
+
+    def _register_listener(self) -> None:
+        if not self.client.sdk:
+            return
+        self._unregister = self.client.sdk.systemManager.listenDevice(
+            self.device_id,
+            ScryptedInterface.ObjectDetector.value,
+            self._on_objects_detected,
+        )
+
+    def _remove_listener(self) -> None:
+        if self._unregister:
+            self._unregister.removeListener()
+            self._unregister = None
+
+    @callback
+    def _handle_reconnect(self, connected: bool) -> None:
+        if connected:
+            self._remove_listener()
+            self._register_listener()
+        self.async_write_ha_state()
+
+    def _on_objects_detected(self, device, event_details: dict, data: Any) -> None:
+        """Fire one event per detected class; runs on the HA loop via the engine.io read task."""
+        detections = (data or {}).get("detections") or []
+        seen: set[str] = set()
+        for detection in detections:
+            class_name = detection.get("className")
+            if not class_name or class_name == MOTION_CLASS or class_name in seen:
+                continue
+            seen.add(class_name)
+            if class_name not in self._attr_event_types:
+                # event_types is fixed at trigger time; extend for unknown classes
+                self._attr_event_types = [*self._attr_event_types, class_name]
+            self._trigger_event(
+                class_name,
+                {
+                    "label": detection.get("label"),
+                    "score": detection.get("score"),
+                    "zones": detection.get("zones"),
+                    "detection_id": (data or {}).get("detectionId"),
+                },
+            )
+        if seen:
+            self.async_write_ha_state()
+
+
+class ScryptedDoorbellEvent(ScryptedDeviceEntity, EventEntity):
+    """Fires on doorbell button presses (binaryState rising edge)."""
+
+    _attr_event_types = ["ring"]
+
+    @callback
+    def _handle_device_update(self, event_details: dict, value: Any) -> None:
+        if event_details.get("property") == "binaryState" and value:
+            self._trigger_event("ring")
+        self.async_write_ha_state()

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,183 @@
+"""Tests for scrypted event entities."""
+
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from custom_components.scrypted.const import SIGNAL_CONNECTION, SIGNAL_NEW_DEVICE
+from tests.conftest import setup_entry
+
+
+async def test_object_detection_event(hass, fake_sdk, enable_custom_integrations):
+    """Object detection event."""
+    await setup_entry(hass)
+
+    state = hass.states.get("event.porch_front_door_cam_object_detected")
+    assert state is not None
+    assert "person" in state.attributes["event_types"]
+
+    fake_sdk.systemManager.fire_device_event(
+        "cam1",
+        "ObjectDetector",
+        {
+            "detections": [
+                {"className": "person", "score": 0.92, "zones": ["porch"]},
+            ],
+            "timestamp": 1,
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("event.porch_front_door_cam_object_detected")
+    assert state.attributes["event_type"] == "person"
+    assert state.attributes["score"] == 0.92
+
+
+async def test_unknown_detection_class_extends_event_types(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Unknown detection class extends event types."""
+    await setup_entry(hass)
+    fake_sdk.systemManager.fire_device_event(
+        "cam1",
+        "ObjectDetector",
+        {"detections": [{"className": "raccoon", "score": 0.5}], "timestamp": 1},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("event.porch_front_door_cam_object_detected")
+    assert state.attributes["event_type"] == "raccoon"
+
+
+async def test_doorbell_press_event(hass, fake_sdk, enable_custom_integrations):
+    """Doorbell press event."""
+    await setup_entry(hass)
+
+    state = hass.states.get("event.doorbell_doorbell")
+    assert state is not None
+
+    fake_sdk.systemManager.set_property("bell1", "binaryState", True)
+    await hass.async_block_till_done()
+    state = hass.states.get("event.doorbell_doorbell")
+    assert state.attributes["event_type"] == "ring"
+
+    # Releasing must not fire another event
+    last_changed = state.last_changed
+    fake_sdk.systemManager.set_property("bell1", "binaryState", False)
+    await hass.async_block_till_done()
+    assert hass.states.get("event.doorbell_doorbell").last_changed == last_changed
+
+
+async def test_object_types_failure_skips_entity(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Unknown classes -> no entity; motion is filtered so it could never fire."""
+    fake_sdk.systemManager.getDeviceById(
+        "cam1"
+    ).getObjectTypes.side_effect = RuntimeError("nope")
+    await setup_entry(hass)
+    assert hass.states.get("event.porch_front_door_cam_object_detected") is None
+
+
+async def test_motion_only_detector_skips_entity(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Motion-only detectors are covered by the motion binary_sensor."""
+    fake_sdk.systemManager.getDeviceById("cam1").getObjectTypes.return_value = {
+        "classes": ["motion"]
+    }
+    await setup_entry(hass)
+    assert hass.states.get("event.porch_front_door_cam_object_detected") is None
+
+
+async def test_motion_class_excluded_from_event_types(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Motion class excluded from event types."""
+    fake_sdk.systemManager.getDeviceById("cam1").getObjectTypes.return_value = {
+        "classes": ["motion", "person", "car"]
+    }
+    await setup_entry(hass)
+    state = hass.states.get("event.porch_front_door_cam_object_detected")
+    assert state.attributes["event_types"] == ["person", "car"]
+
+
+async def test_motion_detections_do_not_fire_events(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Motion detections do not fire events."""
+    await setup_entry(hass)
+
+    # scrypted's motion pipeline reports motion as a detection class; the
+    # motion binary_sensor owns that signal, so the event entity ignores it.
+    fake_sdk.systemManager.fire_device_event(
+        "cam1",
+        "ObjectDetector",
+        {"detections": [{"className": "motion", "score": 1}], "timestamp": 1},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("event.porch_front_door_cam_object_detected")
+    assert state.state == "unknown"
+    assert "motion" not in state.attributes["event_types"]
+
+    # mixed payloads only fire the classified objects
+    fake_sdk.systemManager.fire_device_event(
+        "cam1",
+        "ObjectDetector",
+        {
+            "detections": [
+                {"className": "motion", "score": 1},
+                {"className": "person", "score": 0.9},
+            ],
+            "timestamp": 2,
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("event.porch_front_door_cam_object_detected")
+    assert state.attributes["event_type"] == "person"
+    assert "motion" not in state.attributes["event_types"]
+
+
+async def test_detection_without_class_ignored(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Detection without class ignored."""
+    await setup_entry(hass)
+    fake_sdk.systemManager.fire_device_event(
+        "cam1", "ObjectDetector", {"detections": [{"score": 1.0}], "timestamp": 1}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("event.porch_front_door_cam_object_detected")
+    assert state.state == "unknown"
+
+
+async def test_connection_signal_handling(hass, fake_sdk, enable_custom_integrations):
+    """Connection signal handling."""
+    entry = await setup_entry(hass)
+    client = entry.runtime_data.client
+    signal = SIGNAL_CONNECTION.format(entry.entry_id)
+
+    # connection lost: no re-register, state written
+    async_dispatcher_send(hass, signal, False)
+    await hass.async_block_till_done()
+
+    # reconnected: object detection listener re-registers
+    async_dispatcher_send(hass, signal, True)
+    await hass.async_block_till_done()
+    assert ("cam1", "ObjectDetector") in fake_sdk.systemManager.device_listeners
+
+    # reconnected while sdk unset: register is a guarded no-op
+    client.sdk = None
+    async_dispatcher_send(hass, signal, True)
+    await hass.async_block_till_done()
+    client.sdk = fake_sdk
+
+
+async def test_new_device_signal_unknown_id_ignored(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """A new-device announcement for an id scrypted cannot resolve adds nothing."""
+    entry = await setup_entry(hass)
+    before = len(hass.states.async_all("event"))
+
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "ghost")
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all("event")) == before


### PR DESCRIPTION
## Summary

Second platform PR after the device-entities foundation (#47) and binary sensors (#50). Adds an `event` platform for the stateless scrypted events that matter for automations:

- **Object detected** (`EventDeviceClass.MOTION`): created for allowlisted devices exposing `ObjectDetector` whose `getObjectTypes()` reports at least one class other than `motion`. Event types are seeded from the reported classes (`person`, `car`, `animal`, ...). Each detection payload fires at most one event per class, with `label`, `score`, `zones` and `detection_id` attributes. A class the detector did not advertise up front is appended to the event types before firing, so nothing is dropped.
- **Doorbell** (`EventDeviceClass.DOORBELL`, single type `ring`): created for `Doorbell` devices with the `BinarySensor` interface. Fires on the rising edge of `binaryState` only, so a release does not produce a second event.

Motion is deliberately excluded from the object event: scrypted's motion pipeline reports `motion` as a detection class, and that signal is already owned by the motion binary sensor from #50.

Stateless `ObjectsDetected` payloads do not reach `systemManager.listen`, so the object event entity owns a per-device `listenDevice` subscription. It re-registers after every reconnect and tears down on entity removal.

## Test plan

- [x] `pytest` — 124 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit
- [x] Live-verified in the original device-entities branch (#43) against a scrypted NVR with person/vehicle detection and a doorbell

🤖 Generated with [Claude Code](https://claude.com/claude-code)
