### PR TITLE
feat: device sensors for scrypted measurement interfaces

### DIFF
--- a/custom_components/scrypted/sensor.py
+++ b/custom_components/scrypted/sensor.py
@@ -1,12 +1,151 @@
-"""Representation of Z-Wave sensors."""
+"""Sensors for the Scrypted integration."""
 
-from homeassistant.components.sensor import SensorEntity
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.const import (
+    CONF_HOST,
+    LIGHT_LUX,
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfDensity,
+    UnitOfRatio,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedSensorDescription(
+    SensorEntityDescription, ScryptedEntityDescriptionMixin
+):
+    """Describes a scrypted sensor."""
+
+
+SENSORS: tuple[ScryptedSensorDescription, ...] = (
+    ScryptedSensorDescription(
+        key="temperature",
+        name="Temperature",
+        interface="Thermometer",
+        state_property="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="humidity",
+        name="Humidity",
+        interface="HumiditySensor",
+        state_property="humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="battery",
+        name="Battery",
+        interface="Battery",
+        state_property="batteryLevel",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ScryptedSensorDescription(
+        key="ambient_light",
+        name="Ambient light",
+        interface="AmbientLightSensor",
+        state_property="ambientLight",
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        native_unit_of_measurement=LIGHT_LUX,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="luminance",
+        name="Luminance",
+        interface="LuminanceSensor",
+        state_property="luminance",
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        native_unit_of_measurement=LIGHT_LUX,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="ultraviolet",
+        name="UV index",
+        interface="UltravioletSensor",
+        state_property="ultraviolet",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="co2",
+        name="CO2",
+        interface="CO2Sensor",
+        state_property="co2ppm",
+        device_class=SensorDeviceClass.CO2,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="pm25",
+        name="PM2.5",
+        interface="PM25Sensor",
+        state_property="pm25Density",
+        device_class=SensorDeviceClass.PM25,
+        native_unit_of_measurement=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="pm10",
+        name="PM10",
+        interface="PM10Sensor",
+        state_property="pm10Density",
+        device_class=SensorDeviceClass.PM10,
+        native_unit_of_measurement=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="voc",
+        name="VOC",
+        interface="VOCSensor",
+        state_property="vocDensity",
+        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+        native_unit_of_measurement=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="nox",
+        name="NOx",
+        interface="NOXSensor",
+        state_property="noxDensity",
+        native_unit_of_measurement=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ScryptedSensorDescription(
+        key="air_quality",
+        name="Air quality",
+        interface="AirQualitySensor",
+        state_property="airQuality",
+        device_class=SensorDeviceClass.ENUM,
+        options=["Excellent", "Good", "Fair", "Inferior", "Poor", "Unknown"],
+    ),
+)
 
 
 async def async_setup_entry(
@@ -14,13 +153,26 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Scrypted token sensor from config entry."""
+    """Set up Scrypted sensors from config entry."""
     token = next(
         token
         for token, entry in hass.data[DOMAIN].items()
         if entry.entry_id == config_entry.entry_id
     )
     async_add_entities([ScryptedTokenSensor(config_entry, token)])
+
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedSensor]:
+        return [
+            ScryptedSensor(client, config_entry, device_id, description)
+            for description in SENSORS
+            if device_matches(client, device_id, description.interface)
+        ]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
 
 
 class ScryptedTokenSensor(SensorEntity):
@@ -38,3 +190,17 @@ class ScryptedTokenSensor(SensorEntity):
         self._attr_icon = "mdi:shield-key"
         self._attr_should_poll = False
         self._attr_extra_state_attributes = {CONF_HOST: config_entry.data[CONF_HOST]}
+
+
+class ScryptedSensor(ScryptedDeviceEntity, SensorEntity):
+    """A numeric/enum scrypted device property."""
+
+    entity_description: ScryptedSensorDescription
+
+    @property
+    def native_value(self):
+        """Return the converted native value, or None while the property is unset."""
+        value = self.raw_value
+        if value is None:
+            return None
+        return self.entity_description.value_fn(value)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.const import CONF_HOST
 
 from custom_components.scrypted import sensor
 from custom_components.scrypted.const import DOMAIN
+from custom_components.scrypted.sensor import SENSORS, ScryptedSensor
+from tests.conftest import setup_entry
 from tests.const import EXAMPLE_HOST
 
 
@@ -24,6 +28,7 @@ async def test_async_setup_entry_adds_token_sensor(hass):
     """Test case for test_async_setup_entry_adds_token_sensor."""
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: EXAMPLE_HOST})
     entry.add_to_hass(hass)
+    entry.runtime_data = SimpleNamespace(client=None)
     hass.data.setdefault(DOMAIN, {})["token"] = entry
     added = []
 
@@ -33,3 +38,35 @@ async def test_async_setup_entry_adds_token_sensor(hass):
     await sensor.async_setup_entry(hass, entry, _add_entities)
     assert len(added) == 1
     assert added[0].native_value == "token"
+
+
+async def test_device_sensors_created(hass, fake_sdk):
+    """Test case for test_device_sensors_created."""
+    await setup_entry(hass)
+
+    temp = hass.states.get("sensor.basement_basement_leak_temperature")
+    assert temp is not None
+    assert temp.state == "21.5"
+    assert temp.attributes["device_class"] == "temperature"
+
+    battery = hass.states.get("sensor.porch_front_door_cam_battery")
+    assert battery is not None
+    assert battery.state == "80"
+
+
+async def test_sensor_updates_on_event(hass, fake_sdk):
+    """Test case for test_sensor_updates_on_event."""
+    await setup_entry(hass)
+    fake_sdk.systemManager.set_property("leak1", "temperature", 25.0)
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.basement_basement_leak_temperature").state == "25.0"
+
+
+def test_sensor_native_value_none(fake_sdk):
+    """Test case for test_sensor_native_value_none."""
+    client = SimpleNamespace(sdk=fake_sdk, connected=True)
+    entry = MockConfigEntry(domain=DOMAIN)
+    description = next(d for d in SENSORS if d.key == "temperature")
+    entity = ScryptedSensor(client, entry, "leak1", description)
+    fake_sdk.systemManager.systemState["leak1"].pop("temperature")
+    assert entity.native_value is None


### PR DESCRIPTION
## Summary

Third platform PR after #47 and #50. Extends the existing `sensor` platform (which so far only carried the token sensor) with entities for scrypted measurement interfaces:

| Entity | Scrypted interface | Notes |
|---|---|---|
| Temperature | `Thermometer` | °C, measurement |
| Humidity | `HumiditySensor` | % |
| Battery | `Battery` | diagnostic, so cameras and doorbells report it by default |
| Ambient light / Luminance | `AmbientLightSensor` / `LuminanceSensor` | lux |
| UV index | `UltravioletSensor` | no HA device class exists |
| CO2 | `CO2Sensor` | ppm |
| PM2.5 / PM10 | `PM25Sensor` / `PM10Sensor` | µg/m³ |
| VOC / NOx | `VOCSensor` / `NOXSensor` | µg/m³ |
| Air quality | `AirQualitySensor` | enum: Excellent, Good, Fair, Inferior, Poor, Unknown |

Discovery uses the shared platform helper and the device-type allowlist, so with the default options only Battery typically appears. Users add `Sensor`, `Thermostat`, etc. in the integration options to get the rest. The token sensor is still added unconditionally, including when entities are disabled.

## Test plan

- [x] `pytest` — 123 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
