### PR TITLE
feat: media source for browsing scrypted NVR clips

### DIFF
--- a/custom_components/scrypted/manifest.json
+++ b/custom_components/scrypted/manifest.json
@@ -4,7 +4,7 @@
   "after_dependencies": ["media_source"],
   "codeowners": ["@koush"],
   "config_flow": true,
-  "dependencies": ["http", "frontend", "lovelace"],
+  "dependencies": ["http", "frontend", "lovelace", "media_source", "stream"],
   "documentation": "https://github.com/koush/ha_scrypted",
   "homekit": {},
   "integration_type": "service",

--- a/custom_components/scrypted/media_source.py
+++ b/custom_components/scrypted/media_source.py
@@ -1,0 +1,296 @@
+"""Media source exposing scrypted NVR detection clips."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from scrypted_sdk import ScryptedInterface, ScryptedMimeTypes
+from yarl import URL
+
+from homeassistant.components.camera import DynamicStreamSettings
+from homeassistant.components.media_player import BrowseError, MediaClass
+from homeassistant.components.media_source import (
+    BrowseMediaSource,
+    MediaSource,
+    MediaSourceItem,
+    PlayMedia,
+    Unresolvable,
+)
+from homeassistant.components.stream import (
+    FORMAT_CONTENT_TYPE,
+    HLS_PROVIDER,
+    create_stream,
+)
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .entity import device_matches
+
+_LOGGER = logging.getLogger(__name__)
+
+DAYS_SHOWN = 7
+DAY_FORMAT = "%Y-%m-%d"
+
+
+async def async_get_media_source(hass: HomeAssistant) -> ScryptedMediaSource:
+    """Set up the scrypted media source."""
+    return ScryptedMediaSource(hass)
+
+
+def _loaded_entries(hass: HomeAssistant) -> list[ConfigEntry]:
+    return [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state is ConfigEntryState.LOADED
+        and entry.runtime_data.client is not None
+    ]
+
+
+def _entry_token(hass: HomeAssistant, entry_id: str) -> str:
+    """Ingress token for a loaded entry (async_setup_entry registers it before load completes)."""
+    token = next(
+        (
+            token
+            for token, entry in hass.data[DOMAIN].items()
+            if entry.entry_id == entry_id
+        ),
+        None,
+    )
+    if token is None:
+        raise BrowseError(f"Scrypted entry {entry_id} has no ingress token")
+    return token
+
+
+def _proxy_url(token: str, href: str) -> str:
+    """Rewrite a scrypted href to the integration's streaming proxy."""
+    path_qs = URL(href).raw_path_qs
+    return f"/api/scrypted/{token}/{path_qs.lstrip('/')}"
+
+
+def _clip_title(clip: dict) -> str:
+    started = dt_util.as_local(dt_util.utc_from_timestamp(clip["startTime"] / 1000))
+    title = started.strftime("%I:%M:%S %p").lstrip("0")
+    classes = ", ".join(clip.get("detectionClasses") or [])
+    return f"{title} — {classes}" if classes else title
+
+
+def _resource_href(clip: dict, kind: str) -> str | None:
+    return ((clip.get("resources") or {}).get(kind) or {}).get("href")
+
+
+class ScryptedMediaSource(MediaSource):
+    """Browse scrypted NVR detection clips by camera and day."""
+
+    name = "Scrypted NVR"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the media source for the scrypted domain."""
+        super().__init__(DOMAIN)
+        self.hass = hass
+
+    async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
+        """Browse entries, cameras, days, or a day's clips based on the identifier."""
+        # scrypted device/clip ids are internally generated and never contain
+        # "/", so a bounded split is safe here.
+        parts = (item.identifier or "").split("/", 2) if item.identifier else []
+        if not parts:
+            return self._browse_root()
+        entry = self._get_entry(parts[0])
+        if len(parts) == 1:
+            return self._browse_entry(entry)
+        if len(parts) == 2:
+            return self._browse_camera(entry, parts[1])
+        return await self._browse_day(entry, parts[1], parts[2])
+
+    async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
+        """Resolve a clip identifier to a playable MP4 or HLS stream URL."""
+        # scrypted device/clip ids are internally generated and never contain
+        # "/"; a violating clip id just fails the lookup below as Unresolvable.
+        parts = (item.identifier or "").split("/", 3)
+        if len(parts) != 4:
+            raise Unresolvable(f"Invalid clip identifier: {item.identifier}")
+        entry_id, device_id, day_id, clip_id = parts
+        entry = self._get_entry(entry_id, error_cls=Unresolvable)
+        clips = await self._day_clips(entry, device_id, day_id)
+        clip = next((c for c in clips if c.get("id") == clip_id), None)
+        if clip is None:
+            raise Unresolvable(f"Clip {clip_id} not found")
+        token = _entry_token(self.hass, entry_id)
+        href = _resource_href(clip, "video")
+        if href is not None:
+            return PlayMedia(_proxy_url(token, href), "video/mp4")
+        client = entry.runtime_data.client
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        media_object = await device.getVideoClip(clip["videoId"])
+        ffmpeg_input = await client.sdk.mediaManager.convertMediaObjectToJSON(
+            media_object, ScryptedMimeTypes.FFmpegInput.value
+        )
+        urls = ffmpeg_input.get("urls") or []
+        rtsp_url = next(iter(urls), None) or ffmpeg_input.get("url")
+        if not rtsp_url:
+            raise Unresolvable(f"Clip {clip_id} has no playable stream")
+        return await self._async_hls_play_media(rtsp_url)
+
+    async def _async_hls_play_media(self, rtsp_url: str) -> PlayMedia:
+        """Expose an RTSP clip session as browser-playable HLS via HA's stream component."""
+        # scrypted's clip RTSP sessions are TCP; without this PyAV defaults to
+        # UDP and fails with "Invalid data found when processing input".
+        stream = create_stream(
+            self.hass,
+            rtsp_url,
+            options={"rtsp_transport": "tcp"},
+            dynamic_stream_settings=DynamicStreamSettings(),
+        )
+        stream.add_provider(HLS_PROVIDER)
+        await stream.start()
+        return PlayMedia(
+            stream.endpoint_url(HLS_PROVIDER), FORMAT_CONTENT_TYPE[HLS_PROVIDER]
+        )
+
+    def _get_entry(
+        self, entry_id: str, error_cls: type[Exception] = BrowseError
+    ) -> ConfigEntry:
+        for entry in _loaded_entries(self.hass):
+            if entry.entry_id == entry_id:
+                if entry.runtime_data.client.sdk is None:
+                    raise error_cls(f"Scrypted {entry.title} is disconnected")
+                return entry
+        raise error_cls(f"Scrypted entry {entry_id} is not loaded")
+
+    def _browse_root(self) -> BrowseMediaSource:
+        entries = _loaded_entries(self.hass)
+        if len(entries) == 1 and entries[0].runtime_data.client.sdk is not None:
+            return self._browse_entry(entries[0], as_root=True)
+        return self._node(
+            identifier="",
+            title="Scrypted NVR",
+            children=[
+                self._node(identifier=entry.entry_id, title=entry.title)
+                for entry in entries
+            ],
+        )
+
+    def _browse_entry(
+        self, entry: ConfigEntry, as_root: bool = False
+    ) -> BrowseMediaSource:
+        client = entry.runtime_data.client
+        children = [
+            self._node(
+                identifier=f"{entry.entry_id}/{device_id}",
+                title=client.sdk.systemManager.getDeviceById(device_id).name,
+            )
+            for device_id in client.device_ids
+            if device_matches(client, device_id, ScryptedInterface.VideoClips.value)
+        ]
+        return self._node(
+            identifier="" if as_root else entry.entry_id,
+            title=entry.title,
+            children=children,
+        )
+
+    def _browse_camera(self, entry: ConfigEntry, device_id: str) -> BrowseMediaSource:
+        client = entry.runtime_data.client
+        if not device_matches(client, device_id, ScryptedInterface.VideoClips.value):
+            raise BrowseError(f"Unknown scrypted camera {device_id}")
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        today = dt_util.start_of_local_day()
+        children = []
+        for offset in range(DAYS_SHOWN):
+            day = today - timedelta(days=offset)
+            if offset == 0:
+                title = "Today"
+            elif offset == 1:
+                title = "Yesterday"
+            else:
+                title = f"{day:%A, %b} {day.day}"
+            children.append(
+                self._node(
+                    identifier=(
+                        f"{entry.entry_id}/{device_id}/{day.strftime(DAY_FORMAT)}"
+                    ),
+                    title=title,
+                )
+            )
+        return self._node(
+            identifier=f"{entry.entry_id}/{device_id}",
+            title=device.name,
+            children=children,
+        )
+
+    async def _browse_day(
+        self, entry: ConfigEntry, device_id: str, day_id: str
+    ) -> BrowseMediaSource:
+        clips = await self._day_clips(entry, device_id, day_id)
+        token = _entry_token(self.hass, entry.entry_id)
+        children = []
+        for clip in sorted(
+            (c for c in clips if c.get("startTime") is not None and c.get("id")),
+            key=lambda c: c["startTime"],
+            reverse=True,
+        ):
+            thumbnail_href = _resource_href(clip, "thumbnail")
+            children.append(
+                BrowseMediaSource(
+                    domain=DOMAIN,
+                    identifier=f"{entry.entry_id}/{device_id}/{day_id}/{clip['id']}",
+                    media_class=MediaClass.VIDEO,
+                    media_content_type="video/mp4",
+                    title=_clip_title(clip),
+                    can_play=True,
+                    can_expand=False,
+                    thumbnail=(
+                        _proxy_url(token, thumbnail_href) if thumbnail_href else None
+                    ),
+                )
+            )
+        return self._node(
+            identifier=f"{entry.entry_id}/{device_id}/{day_id}",
+            title=day_id,
+            children=children,
+            children_media_class=MediaClass.VIDEO,
+        )
+
+    async def _day_clips(
+        self, entry: ConfigEntry, device_id: str, day_id: str
+    ) -> list[dict]:
+        client = entry.runtime_data.client
+        if not device_matches(client, device_id, ScryptedInterface.VideoClips.value):
+            raise BrowseError(f"Unknown scrypted camera {device_id}")
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        day = dt_util.parse_date(day_id)
+        if day is None:
+            raise BrowseError(f"Invalid day {day_id}")
+        start = dt_util.start_of_local_day(day)
+        end = dt_util.start_of_local_day(day + timedelta(days=1))
+        start_ms = int(start.timestamp() * 1000)
+        end_ms = int(end.timestamp() * 1000)
+        try:
+            return (
+                await device.getVideoClips({"startTime": start_ms, "endTime": end_ms})
+                or []
+            )
+        except Exception as err:  # noqa: BLE001 - RPC failures surface in the UI
+            _LOGGER.debug("getVideoClips failed for %s", device_id, exc_info=True)
+            raise BrowseError(f"Could not load clips for {device.name}") from err
+
+    def _node(
+        self,
+        identifier: str,
+        title: str,
+        children: list[BrowseMediaSource] | None = None,
+        children_media_class: MediaClass = MediaClass.DIRECTORY,
+    ) -> BrowseMediaSource:
+        return BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=identifier,
+            media_class=MediaClass.DIRECTORY,
+            media_content_type="",
+            title=title,
+            can_play=False,
+            can_expand=True,
+            children=children,
+            children_media_class=children_media_class,
+        )

--- a/custom_components/scrypted/media_source.py
+++ b/custom_components/scrypted/media_source.py
@@ -114,17 +114,19 @@ class ScryptedMediaSource(MediaSource):
             raise Unresolvable(f"Invalid clip identifier: {item.identifier}")
         entry_id, device_id, day_id, clip_id = parts
         entry = self._get_entry(entry_id, error_cls=Unresolvable)
-        clips = await self._day_clips(entry, device_id, day_id)
+        clips = await self._day_clips(entry, device_id, day_id, error_cls=Unresolvable)
         clip = next((c for c in clips if c.get("id") == clip_id), None)
         if clip is None:
             raise Unresolvable(f"Clip {clip_id} not found")
         token = _entry_token(self.hass, entry_id)
         href = _resource_href(clip, "video")
-        if href is not None:
+        if href:
             return PlayMedia(_proxy_url(token, href), "video/mp4")
         client = entry.runtime_data.client
         device = client.sdk.systemManager.getDeviceById(device_id)
-        media_object = await device.getVideoClip(clip["videoId"])
+        # NVR clips carry videoId; fall back to the clip id, which scrypted
+        # uses for both.
+        media_object = await device.getVideoClip(clip.get("videoId") or clip_id)
         ffmpeg_input = await client.sdk.mediaManager.convertMediaObjectToJSON(
             media_object, ScryptedMimeTypes.FFmpegInput.value
         )
@@ -144,8 +146,13 @@ class ScryptedMediaSource(MediaSource):
             options={"rtsp_transport": "tcp"},
             dynamic_stream_settings=DynamicStreamSettings(),
         )
-        stream.add_provider(HLS_PROVIDER)
+        provider = stream.add_provider(HLS_PROVIDER)
         await stream.start()
+        # The idle timer normally arms on the first segment, so a session that
+        # never produces one would keep its worker thread for the life of the
+        # process. Arming it here lets the stream clean itself up; fetching the
+        # playlist resets it to the usual idle timeout.
+        provider.idle_timer.start()
         return PlayMedia(
             stream.endpoint_url(HLS_PROVIDER), FORMAT_CONTENT_TYPE[HLS_PROVIDER]
         )
@@ -254,15 +261,19 @@ class ScryptedMediaSource(MediaSource):
         )
 
     async def _day_clips(
-        self, entry: ConfigEntry, device_id: str, day_id: str
+        self,
+        entry: ConfigEntry,
+        device_id: str,
+        day_id: str,
+        error_cls: type[Exception] = BrowseError,
     ) -> list[dict]:
         client = entry.runtime_data.client
         if not device_matches(client, device_id, ScryptedInterface.VideoClips.value):
-            raise BrowseError(f"Unknown scrypted camera {device_id}")
+            raise error_cls(f"Unknown scrypted camera {device_id}")
         device = client.sdk.systemManager.getDeviceById(device_id)
         day = dt_util.parse_date(day_id)
         if day is None:
-            raise BrowseError(f"Invalid day {day_id}")
+            raise error_cls(f"Invalid day {day_id}")
         start = dt_util.start_of_local_day(day)
         end = dt_util.start_of_local_day(day + timedelta(days=1))
         start_ms = int(start.timestamp() * 1000)
@@ -274,7 +285,7 @@ class ScryptedMediaSource(MediaSource):
             )
         except Exception as err:  # noqa: BLE001 - RPC failures surface in the UI
             _LOGGER.debug("getVideoClips failed for %s", device_id, exc_info=True)
-            raise BrowseError(f"Could not load clips for {device.name}") from err
+            raise error_cls(f"Could not load clips for {device.name}") from err
 
     def _node(
         self,

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -1,0 +1,328 @@
+"""Tests for the scrypted NVR clips media source."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.components import media_source
+from homeassistant.components.media_player import BrowseError
+from homeassistant.components.stream import FORMAT_CONTENT_TYPE, HLS_PROVIDER
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from custom_components import scrypted
+from custom_components.scrypted.const import (
+    CONF_AUTO_REGISTER_RESOURCES,
+    CONF_DEVICE_TYPES,
+    CONF_ENABLE_ENTITIES,
+    CONF_SCRYPTED_NVR,
+    DOMAIN,
+)
+from custom_components.scrypted.media_source import _entry_token
+from tests.conftest import setup_entry, video_clip
+
+
+def today_ms(hour=15, minute=42, second=7):
+    """Epoch millis for a time within today's local day."""
+    now = dt_util.now()
+    stamp = now.replace(hour=hour, minute=minute, second=second, microsecond=0)
+    return int(stamp.timestamp() * 1000)
+
+
+async def setup_media_source(hass):
+    """Set up a scrypted entry and the media_source component."""
+    entry = await setup_entry(hass)
+    assert await async_setup_component(hass, "media_source", {})
+    return entry
+
+
+async def test_browse_root_lists_eligible_cameras(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Browse root lists eligible cameras."""
+    await setup_media_source(hass)
+    root = await media_source.async_browse_media(hass, "media-source://scrypted")
+    titles = [child.title for child in root.children]
+    # cam1 has VideoClips; bell1/haimport1/others do not (or are excluded)
+    assert titles == ["Front Door Cam"]
+    assert root.children[0].can_expand and not root.children[0].can_play
+
+
+async def test_browse_camera_lists_seven_days(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Browse camera lists seven days."""
+    entry = await setup_media_source(hass)
+    camera = await media_source.async_browse_media(
+        hass, f"media-source://scrypted/{entry.entry_id}/cam1"
+    )
+    assert len(camera.children) == 7
+    assert camera.children[0].title == "Today"
+    assert camera.children[1].title == "Yesterday"
+
+
+async def test_browse_day_lists_clips_with_one_rpc(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Browse day lists clips with one rpc."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    device.getVideoClips.return_value = [
+        video_clip(
+            "clip1", today_ms(15, 42, 7), detection_classes=["person", "motion"]
+        ),
+        video_clip("clip2", today_ms(9, 5, 0), detection_classes=[]),
+    ]
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+    day = await media_source.async_browse_media(
+        hass, f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}"
+    )
+
+    device.getVideoClips.assert_awaited_once()
+    window = device.getVideoClips.await_args.args[0]
+    start = dt_util.start_of_local_day()
+    assert window["startTime"] == int(start.timestamp() * 1000)
+    assert window["endTime"] == window["startTime"] + 24 * 3600 * 1000
+
+    assert [c.title for c in day.children] == [
+        "3:42:07 PM — person, motion",
+        "9:05:00 AM",
+    ]
+    clip = day.children[0]
+    assert clip.can_play and not clip.can_expand
+    assert (
+        clip.thumbnail == "/api/scrypted/token/endpoint/@scrypted/nvr/public/clip1.jpg"
+    )
+
+
+async def test_day_window_spans_dst_transition(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Fall-back day in America/New_York is 25 hours; the window must cover all of it."""
+    await hass.config.async_set_time_zone("America/New_York")
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+
+    await media_source.async_browse_media(
+        hass, f"media-source://scrypted/{entry.entry_id}/cam1/2026-11-01"
+    )
+    window = device.getVideoClips.await_args.args[0]
+    assert window["endTime"] - window["startTime"] == 25 * 3600 * 1000
+
+
+async def test_resolve_clip_with_resources(hass, fake_sdk, enable_custom_integrations):
+    """Resolve clip with resources."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    device.getVideoClips.return_value = [video_clip("clip1", today_ms())]
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+
+    play = await media_source.async_resolve_media(
+        hass, f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}/clip1", None
+    )
+    assert play.url == "/api/scrypted/token/endpoint/@scrypted/nvr/public/clip1.mp4"
+    assert play.mime_type == "video/mp4"
+
+
+async def test_resolve_clip_without_resources_falls_back(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Resolve clip without resources falls back."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    device.getVideoClips.return_value = [
+        video_clip("clip1", today_ms(), with_resources=False)
+    ]
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+
+    fake_sdk.mediaManager.convertMediaObjectToJSON.return_value = {
+        "url": "rtsp://127.0.0.1:1/x",
+        "urls": ["rtsp://192.168.0.9:1/x"],
+    }
+
+    fake_stream = Mock()
+    fake_stream.add_provider = Mock()
+    fake_stream.start = AsyncMock()
+    fake_stream.endpoint_url = Mock(return_value="/api/hls/xyz/master_playlist.m3u8")
+    create_stream_mock = Mock(return_value=fake_stream)
+    with patch(
+        "custom_components.scrypted.media_source.create_stream", create_stream_mock
+    ):
+        play = await media_source.async_resolve_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}/clip1", None
+        )
+
+    device.getVideoClip.assert_awaited_once_with("clip1")
+    fake_sdk.mediaManager.convertMediaObjectToJSON.assert_awaited_once()
+    assert (
+        fake_sdk.mediaManager.convertMediaObjectToJSON.await_args.args[1]
+        == "x-scrypted/x-ffmpeg-input"
+    )
+    assert create_stream_mock.call_args.args[1] == "rtsp://192.168.0.9:1/x"
+    fake_stream.add_provider.assert_called_once_with(HLS_PROVIDER)
+    fake_stream.start.assert_awaited_once()
+    assert play.url == "/api/hls/xyz/master_playlist.m3u8"
+    assert play.mime_type == FORMAT_CONTENT_TYPE[HLS_PROVIDER]
+
+
+async def test_resolve_clip_ffmpeg_input_without_urls_unresolvable(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Resolve clip ffmpeg input without urls unresolvable."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    device.getVideoClips.return_value = [
+        video_clip("clip1", today_ms(), with_resources=False)
+    ]
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+
+    fake_sdk.mediaManager.convertMediaObjectToJSON.return_value = {"container": "rtsp"}
+
+    with pytest.raises(media_source.Unresolvable, match="clip1"):
+        await media_source.async_resolve_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}/clip1", None
+        )
+
+
+async def test_resolve_unknown_clip_unresolvable(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Resolve unknown clip unresolvable."""
+    entry = await setup_media_source(hass)
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+    with pytest.raises(media_source.Unresolvable, match="ghost"):
+        await media_source.async_resolve_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}/ghost", None
+        )
+
+
+async def test_browse_errors(hass, fake_sdk, enable_custom_integrations):
+    """Browse errors."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+
+    # RPC failure surfaces as BrowseError
+    device.getVideoClips.side_effect = RuntimeError("boom")
+    with pytest.raises(BrowseError):
+        await media_source.async_browse_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}"
+        )
+
+    # unknown device
+    with pytest.raises(BrowseError):
+        await media_source.async_browse_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/nope"
+        )
+
+    # disconnected client
+    entry.runtime_data.client.sdk = None
+    with pytest.raises(BrowseError):
+        await media_source.async_browse_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/cam1"
+        )
+    entry.runtime_data.client.sdk = fake_sdk
+
+
+async def test_malformed_clip_skipped(hass, fake_sdk, enable_custom_integrations):
+    """Malformed clip skipped."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    good = video_clip("ok", today_ms())
+    bad = video_clip("bad", today_ms())
+    del bad["startTime"]
+    device.getVideoClips.return_value = [good, bad]
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+    day = await media_source.async_browse_media(
+        hass, f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}"
+    )
+    assert [c.identifier.rsplit("/", 1)[-1] for c in day.children] == ["ok"]
+
+
+async def test_browse_unknown_device_within_day(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Browse unknown device within day."""
+    entry = await setup_media_source(hass)
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+    with pytest.raises(BrowseError):
+        await media_source.async_browse_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/nope/{day_id}"
+        )
+
+
+async def test_browse_invalid_day(hass, fake_sdk, enable_custom_integrations):
+    """Browse invalid day."""
+    entry = await setup_media_source(hass)
+    with pytest.raises(BrowseError):
+        await media_source.async_browse_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/cam1/not-a-day"
+        )
+
+
+async def test_browse_unknown_entry(hass, fake_sdk, enable_custom_integrations):
+    """Browse unknown entry."""
+    await setup_media_source(hass)
+    with pytest.raises(BrowseError):
+        await media_source.async_browse_media(
+            hass, "media-source://scrypted/ghost-entry"
+        )
+
+
+async def test_resolve_malformed_identifier(hass, fake_sdk, enable_custom_integrations):
+    """Resolve malformed identifier."""
+    entry = await setup_media_source(hass)
+    with pytest.raises(media_source.Unresolvable):
+        await media_source.async_resolve_media(
+            hass, f"media-source://scrypted/{entry.entry_id}/cam1", None
+        )
+
+
+async def test_entry_token_missing_raises_browse_error(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Entry token missing raises browse error."""
+    await setup_media_source(hass)
+    with pytest.raises(BrowseError, match="missing"):
+        _entry_token(hass, "missing")
+
+
+async def test_browse_root_with_multiple_entries_lists_entries(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Browse root with multiple entries lists entries."""
+    entry1 = await setup_media_source(hass)
+
+    async def _fake_retrieve(data, session):
+        return "token2"
+
+    entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "5.6.7.8",
+            "username": "u2",
+            "password": "p2",
+            "name": "Scrypted 2",
+            "icon": "mdi:memory",
+        },
+        options={
+            CONF_AUTO_REGISTER_RESOURCES: False,
+            CONF_SCRYPTED_NVR: False,
+            CONF_ENABLE_ENTITIES: True,
+            CONF_DEVICE_TYPES: ["Camera", "Doorbell", "Sensor"],
+        },
+    )
+    entry2.add_to_hass(hass)
+    with patch.object(scrypted, "retrieve_token", _fake_retrieve):
+        assert await hass.config_entries.async_setup(entry2.entry_id)
+        await hass.async_block_till_done()
+
+    root = await media_source.async_browse_media(hass, "media-source://scrypted")
+    titles = {child.title for child in root.children}
+    assert titles == {entry1.title, entry2.title}
+
+    camera = await media_source.async_browse_media(
+        hass, f"media-source://scrypted/{entry1.entry_id}"
+    )
+    assert [child.title for child in camera.children] == ["Front Door Cam"]

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -1,5 +1,6 @@
 """Tests for the scrypted NVR clips media source."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -7,6 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import BrowseError
+from homeassistant.components.media_source import Unresolvable
 from homeassistant.components.stream import FORMAT_CONTENT_TYPE, HLS_PROVIDER
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -82,8 +84,11 @@ async def test_browse_day_lists_clips_with_one_rpc(
     device.getVideoClips.assert_awaited_once()
     window = device.getVideoClips.await_args.args[0]
     start = dt_util.start_of_local_day()
+    end = dt_util.start_of_local_day(start.date() + timedelta(days=1))
     assert window["startTime"] == int(start.timestamp() * 1000)
-    assert window["endTime"] == window["startTime"] + 24 * 3600 * 1000
+    # A local day is 23 or 25 hours across a DST change, so derive the end
+    # rather than assuming 24 hours.
+    assert window["endTime"] == int(end.timestamp() * 1000)
 
     assert [c.title for c in day.children] == [
         "3:42:07 PM — person, motion",
@@ -326,3 +331,47 @@ async def test_browse_root_with_multiple_entries_lists_entries(
         hass, f"media-source://scrypted/{entry1.entry_id}"
     )
     assert [child.title for child in camera.children] == ["Front Door Cam"]
+
+
+async def test_resolve_rpc_failure_is_unresolvable(hass, fake_sdk):
+    """A failure while resolving surfaces as Unresolvable, not BrowseError."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    device.getVideoClips.side_effect = RuntimeError("rpc down")
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+
+    with pytest.raises(Unresolvable):
+        await media_source.async_resolve_media(
+            hass,
+            f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}/clip1",
+            None,
+        )
+
+
+async def test_resolve_empty_video_href_falls_back_to_stream(hass, fake_sdk):
+    """An empty video href is not a playable URL and falls through to HLS."""
+    entry = await setup_media_source(hass)
+    device = fake_sdk.systemManager.getDeviceById("cam1")
+    clip = video_clip("clip1", today_ms(15, 42, 7))
+    clip["resources"]["video"]["href"] = ""
+    clip.pop("videoId")
+    device.getVideoClips.return_value = [clip]
+    day_id = dt_util.now().strftime("%Y-%m-%d")
+
+    with patch(
+        "custom_components.scrypted.media_source.create_stream"
+    ) as mock_create_stream:
+        stream = mock_create_stream.return_value
+        stream.start = AsyncMock()
+        stream.endpoint_url.return_value = "/api/hls/abc/master_playlist.m3u8"
+        result = await media_source.async_resolve_media(
+            hass,
+            f"media-source://scrypted/{entry.entry_id}/cam1/{day_id}/clip1",
+            None,
+        )
+
+    assert result.url == "/api/hls/abc/master_playlist.m3u8"
+    # Missing videoId falls back to the clip id.
+    device.getVideoClip.assert_awaited_once_with("clip1")
+    # The stream must not outlive a session that never produces data.
+    stream.add_provider.return_value.idle_timer.start.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a `media_source` platform so scrypted NVR detection clips show up in Home Assistant's media browser. Builds only on the device-entities foundation (#47); it does not depend on the other platform PRs.

**Hierarchy:** Scrypted → entry (collapsed when there is exactly one connected entry) → cameras exposing `VideoClips` → Today, Yesterday and five more days → clips newest first, titled like `3:42:07 PM — person, motion`. Cameras are filtered through the same allowlist and HA-plugin exclusion as entities. Browsing a day is a single `getVideoClips` RPC.

**Delivery:** thumbnails and MP4 hrefs are rewritten to the existing `/api/scrypted/{token}/...` proxy so they reuse ScryptedView's bearer auth. Resolving a clip plays a direct MP4 when the clip carries a video href. Otherwise it fetches the clip's `FFmpegInput` and creates an HA stream served as HLS, forcing RTSP over TCP because scrypted's clip sessions are TCP-only and PyAV defaults to UDP.

**Manifest:** adds `media_source` and `stream` to dependencies.

## Known limitations

- HLS clips play inline on Safari/iOS, the companion apps and Chromecast. Chrome/desktop go through HA's generic media dialog, which does not load hls.js, so inline playback there is not guaranteed. Universal inline playback would need an async NVR MP4 export flow; noted as a follow-up.
- Seven days are listed; older clips are not browsable.
- Resolving a clip re-fetches the day's clip list to locate it. There is no caching between browse and resolve.
- Day windows use the local start of day, so DST transition days are 23 or 25 hours long. A test covers the 25-hour case.

## Test plan

- [x] `pytest` — 129 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit
- [x] Browse, thumbnails and clip playback verified live in the original branch (#43) against a scrypted NVR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
