### PR TITLE
feat: speaker media players for scrypted intercom devices

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -59,6 +59,7 @@ class ScryptedRuntimeData:
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.MEDIA_PLAYER,
     Platform.SENSOR,
 ]
 

--- a/custom_components/scrypted/manifest.json
+++ b/custom_components/scrypted/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "scrypted",
   "name": "Scrypted",
+  "after_dependencies": ["media_source"],
   "codeowners": ["@koush"],
   "config_flow": true,
   "dependencies": ["http", "frontend", "lovelace"],

--- a/custom_components/scrypted/media_player.py
+++ b/custom_components/scrypted/media_player.py
@@ -1,0 +1,111 @@
+"""Media player entities for Scrypted intercom-capable devices.
+
+Camera entities are snapshot-only (live view happens in the Scrypted NVR
+cards), so two-way audio is exposed the HA-native way instead: each scrypted
+Intercom device becomes a speaker media_player that plays URLs/TTS through the
+camera or doorbell speaker.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components import media_source
+from homeassistant.components.media_player import (
+    BrowseMedia,
+    MediaPlayerDeviceClass,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+    async_process_play_media_url,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import ScryptedDeviceEntity, async_setup_scrypted_platform, device_matches
+
+_LOGGER = logging.getLogger(__name__)
+
+SPEAKER_DESCRIPTION = EntityDescription(key="speaker", name="Speaker")
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted intercom media players."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedIntercom]:
+        if not device_matches(client, device_id, ScryptedInterface.Intercom.value):
+            return []
+        return [ScryptedIntercom(client, config_entry, device_id, SPEAKER_DESCRIPTION)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedIntercom(ScryptedDeviceEntity, MediaPlayerEntity):
+    """Plays audio through a scrypted Intercom device's speaker."""
+
+    _attr_device_class = MediaPlayerDeviceClass.SPEAKER
+    _attr_supported_features = (
+        MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.MEDIA_ANNOUNCE
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
+    )
+    _attr_state = MediaPlayerState.IDLE
+
+    async def async_play_media(
+        self,
+        media_type: str,
+        media_id: str,
+        announce: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Resolve the media to a URL and play it through the intercom."""
+        device = self.device
+        if device is None or not self.client.sdk:
+            raise HomeAssistantError(
+                f"Scrypted device for {self.entity_id} is unavailable"
+            )
+        if media_source.is_media_source_id(media_id):
+            play_item = await media_source.async_resolve_media(
+                self.hass, media_id, self.entity_id
+            )
+            media_id = play_item.url
+        # The scrypted server fetches the URL itself, so it must be absolute.
+        media_id = async_process_play_media_url(self.hass, media_id)
+        media_object = await self.client.sdk.mediaManager.createMediaObjectFromUrl(
+            media_id
+        )
+        await device.startIntercom(media_object)
+        self._attr_state = MediaPlayerState.PLAYING
+        self.async_write_ha_state()
+
+    async def async_media_stop(self) -> None:
+        """Stop intercom playback."""
+        device = self.device
+        if device is not None:
+            await device.stopIntercom()
+        self._attr_state = MediaPlayerState.IDLE
+        self.async_write_ha_state()
+
+    async def async_browse_media(
+        self, media_content_type: str | None = None, media_content_id: str | None = None
+    ) -> BrowseMedia:
+        """Browse audio from media sources (local media, TTS, etc.)."""
+        return await media_source.async_browse_media(
+            self.hass,
+            media_content_id,
+            content_filter=lambda item: item.media_content_type.startswith("audio/"),
+        )

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1,0 +1,112 @@
+"""Tests for scrypted intercom media players."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.conftest import setup_entry
+
+
+async def test_intercom_media_player_created(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Intercom media player created."""
+    await setup_entry(hass)
+    state = hass.states.get("media_player.doorbell_speaker")
+    assert state is not None
+    assert state.state == "idle"
+    # cam1 has no Intercom interface -> no media player
+    assert hass.states.get("media_player.porch_front_door_cam_speaker") is None
+
+
+async def test_play_media_url_starts_intercom(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Play media url starts intercom."""
+    await setup_entry(hass)
+    await hass.services.async_call(
+        "media_player",
+        "play_media",
+        {
+            "entity_id": "media_player.doorbell_speaker",
+            "media_content_type": "music",
+            "media_content_id": "http://example/announcement.mp3",
+        },
+        blocking=True,
+    )
+    fake_sdk.mediaManager.createMediaObjectFromUrl.assert_awaited_with(
+        "http://example/announcement.mp3"
+    )
+    device = fake_sdk.systemManager.getDeviceById("bell1")
+    device.startIntercom.assert_awaited()
+    assert hass.states.get("media_player.doorbell_speaker").state == "playing"
+
+    await hass.services.async_call(
+        "media_player",
+        "media_stop",
+        {"entity_id": "media_player.doorbell_speaker"},
+        blocking=True,
+    )
+    device.stopIntercom.assert_awaited()
+    assert hass.states.get("media_player.doorbell_speaker").state == "idle"
+
+
+async def test_play_media_resolves_media_source(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Play media resolves media source."""
+    await setup_entry(hass)
+    resolved = SimpleNamespace(url="/local/tts.mp3", mime_type="audio/mpeg")
+    with patch(
+        "custom_components.scrypted.media_player.media_source.async_resolve_media",
+        AsyncMock(return_value=resolved),
+    ):
+        await hass.services.async_call(
+            "media_player",
+            "play_media",
+            {
+                "entity_id": "media_player.doorbell_speaker",
+                "media_content_type": "music",
+                "media_content_id": "media-source://tts/cloud?message=hi",
+                "announce": True,
+            },
+            blocking=True,
+        )
+    url = fake_sdk.mediaManager.createMediaObjectFromUrl.await_args.args[0]
+    # relative URL is made absolute (and auth-signed) for the scrypted server
+    assert "/local/tts.mp3" in url
+    assert url.startswith("http")
+
+
+async def test_play_media_unavailable_device_raises(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Play media unavailable device raises."""
+    await setup_entry(hass)
+    component = hass.data["media_player"]
+    entity = component.get_entity("media_player.doorbell_speaker")
+    fake_sdk.systemManager.systemState.pop("bell1")
+    with pytest.raises(HomeAssistantError):
+        await entity.async_play_media("music", "http://example/x.mp3")
+    # stop on missing device is a quiet no-op
+    await entity.async_media_stop()
+
+
+async def test_browse_media_delegates_to_media_source(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Browse media delegates to media source."""
+    await setup_entry(hass)
+    sentinel = object()
+    with patch(
+        "custom_components.scrypted.media_player.media_source.async_browse_media",
+        AsyncMock(return_value=sentinel),
+    ) as browse:
+        component = hass.data["media_player"]
+        entity = component.get_entity("media_player.doorbell_speaker")
+        result = await entity.async_browse_media(None, None)
+    assert result is sentinel
+    browse.assert_awaited()


### PR DESCRIPTION
## Summary

Cameras in this integration are snapshot-only by design (#47), so two-way audio is exposed the HA-native way instead: every scrypted device with the `Intercom` interface (doorbells, two-way cameras) becomes a `media_player.<device>_speaker` entity with device class speaker and the PLAY_MEDIA, STOP, MEDIA_ANNOUNCE and BROWSE_MEDIA features. Plain cameras without `Intercom` get no media player.

- `play_media` resolves `media-source://` IDs through HA's media source, runs the result through `async_process_play_media_url` so relative and TTS URLs become absolute signed URLs the scrypted server can fetch, wraps it in a scrypted media object and calls `startIntercom`. `announce: true` takes the same path, so "say to media player" TTS works.
- `media_stop` calls `stopIntercom`.
- `browse_media` delegates to the HA media-source browser filtered to audio.
- **Manifest:** adds `after_dependencies: ["media_source"]`, which hassfest requires for the `media_source` import.

## Caveat

State is optimistic: `playing` after start and `idle` after stop. Scrypted gives no playback-complete feedback, so the entity stays `playing` until `media_stop` is called.

## Test plan

- [x] `pytest` — 118 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit
- [x] TTS through a doorbell speaker verified live in the original branch (#43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
