### PR TITLE
feat: switch and lock platforms for controllable scrypted devices

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -59,7 +59,9 @@ class ScryptedRuntimeData:
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.LOCK,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/scrypted/lock.py
+++ b/custom_components/scrypted/lock.py
@@ -1,0 +1,81 @@
+"""Lock entities for scrypted Lock devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.lock import LockEntity, LockEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedLockDescription(LockEntityDescription, ScryptedEntityDescriptionMixin):
+    """Describe a scrypted lock."""
+
+
+LOCK = ScryptedLockDescription(
+    key="lock",
+    name=None,
+    interface=ScryptedInterface.Lock.value,
+    state_property="lockState",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted locks."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedLock]:
+        if client.sdk is None:
+            return []
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None or device.type != "Lock":
+            return []
+        if not device_matches(client, device_id, LOCK.interface):
+            return []
+        return [ScryptedLock(client, config_entry, device_id, LOCK)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedLock(ScryptedDeviceEntity, LockEntity):
+    """Lock/unlock control backed by scrypted lockState."""
+
+    entity_description: ScryptedLockDescription
+
+    @property
+    def is_locked(self) -> bool | None:
+        """Return True when lockState is Locked, None when unknown."""
+        value = self.raw_value
+        return None if value is None else value == "Locked"
+
+    @property
+    def is_jammed(self) -> bool:
+        """Return True when the lock reports a jammed mechanism."""
+        return self.raw_value == "Jammed"
+
+    async def async_lock(self, **kwargs: Any) -> None:
+        """Lock the device."""
+        await self._async_device_command("lock")
+
+    async def async_unlock(self, **kwargs: Any) -> None:
+        """Unlock the device."""
+        await self._async_device_command("unlock")

--- a/custom_components/scrypted/switch.py
+++ b/custom_components/scrypted/switch.py
@@ -1,0 +1,96 @@
+"""Switch entities for controllable scrypted devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedSwitchDescription(
+    SwitchEntityDescription, ScryptedEntityDescriptionMixin
+):
+    """Describe a scrypted switch."""
+
+
+# Keyed by scrypted device type; both share key="switch" so unique_ids are stable
+# if a device is later reclassified between Switch and Outlet.
+SWITCH_DESCRIPTIONS: dict[str, ScryptedSwitchDescription] = {
+    "Switch": ScryptedSwitchDescription(
+        key="switch",
+        name=None,
+        device_class=SwitchDeviceClass.SWITCH,
+        interface=ScryptedInterface.OnOff.value,
+        state_property="on",
+    ),
+    "Outlet": ScryptedSwitchDescription(
+        key="switch",
+        name=None,
+        device_class=SwitchDeviceClass.OUTLET,
+        interface=ScryptedInterface.OnOff.value,
+        state_property="on",
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted switches."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedSwitch]:
+        if client.sdk is None:
+            return []
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None:
+            return []
+        description = SWITCH_DESCRIPTIONS.get(device.type or "")
+        if description is None:
+            return []
+        if not device_matches(client, device_id, description.interface):
+            return []
+        return [ScryptedSwitch(client, config_entry, device_id, description)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedSwitch(ScryptedDeviceEntity, SwitchEntity):
+    """OnOff control for scrypted Switch/Outlet devices."""
+
+    entity_description: ScryptedSwitchDescription
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the device reports itself on."""
+        return self.raw_value
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        await self._async_device_command("turnOn")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        await self._async_device_command("turnOff")

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,65 @@
+"""Tests for scrypted locks."""
+
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from custom_components.scrypted.const import SIGNAL_NEW_DEVICE
+from tests.conftest import setup_entry
+
+TYPES = ["Camera", "Doorbell", "Lock"]
+
+
+async def test_lock_discovered_and_states(hass, fake_sdk, enable_custom_integrations):
+    """Lock discovered and states."""
+    await setup_entry(hass, device_types=TYPES)
+    assert hass.states.get("lock.side_door").state == "locked"
+
+    fake_sdk.systemManager.set_property("lock1", "lockState", "Unlocked")
+    await hass.async_block_till_done()
+    assert hass.states.get("lock.side_door").state == "unlocked"
+
+    fake_sdk.systemManager.set_property("lock1", "lockState", "Jammed")
+    await hass.async_block_till_done()
+    assert hass.states.get("lock.side_door").state == "jammed"
+
+
+async def test_lock_not_in_allowlist_skipped(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Lock device present but excluded from the configured type allowlist."""
+    await setup_entry(hass, device_types=["Camera", "Doorbell"])
+    assert hass.states.get("lock.side_door") is None
+
+
+async def test_lock_commands(hass, fake_sdk, enable_custom_integrations):
+    """Lock commands."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("lock1")
+
+    await hass.services.async_call(
+        "lock", "unlock", {"entity_id": "lock.side_door"}, blocking=True
+    )
+    device.unlock.assert_awaited_once()
+
+    await hass.services.async_call(
+        "lock", "lock", {"entity_id": "lock.side_door"}, blocking=True
+    )
+    device.lock.assert_awaited_once()
+
+
+async def test_new_device_signal_ignored_for_unknown_or_disconnected(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """New device signal ignored for unknown or disconnected."""
+    entry = await setup_entry(hass, device_types=TYPES)
+    before = len(hass.states.async_entity_ids("lock"))
+
+    # unknown device id: getDeviceById returns None
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "nope")
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids("lock")) == before
+
+    # SDK dropped (disconnected) while a new-device signal arrives
+    entry.runtime_data.client.sdk = None
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "lock1")
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids("lock")) == before

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,88 @@
+"""Tests for scrypted switches."""
+
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from custom_components.scrypted.const import SIGNAL_NEW_DEVICE
+from tests.conftest import setup_entry, state
+
+TYPES = ["Camera", "Doorbell", "Switch", "Outlet"]
+
+
+async def test_outlet_discovered_with_device_class(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Outlet discovered with device class."""
+    await setup_entry(hass, device_types=TYPES)
+    state_obj = hass.states.get("switch.heater_plug")
+    assert state_obj is not None
+    assert state_obj.state == "on"
+    assert state_obj.attributes["device_class"] == "outlet"
+
+
+async def test_switch_not_discovered_without_allowlist(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Switch not discovered without allowlist."""
+    await setup_entry(hass)  # default allowlist: no Switch/Outlet
+    assert hass.states.get("switch.heater_plug") is None
+
+
+async def test_switch_commands_and_push_update(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Switch commands and push update."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("outlet1")
+
+    await hass.services.async_call(
+        "switch", "turn_off", {"entity_id": "switch.heater_plug"}, blocking=True
+    )
+    device.turnOff.assert_awaited_once()
+    # state is push-confirmed, not optimistic
+    assert hass.states.get("switch.heater_plug").state == "on"
+    fake_sdk.systemManager.set_property("outlet1", "on", False)
+    await hass.async_block_till_done()
+    assert hass.states.get("switch.heater_plug").state == "off"
+
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": "switch.heater_plug"}, blocking=True
+    )
+    device.turnOn.assert_awaited_once()
+
+
+async def test_plain_switch_gets_switch_device_class(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Plain switch gets switch device class."""
+    fake_sdk.systemManager.systemState["switch1"] = state(
+        name="Porch Light Relay",
+        type="Switch",
+        info={},
+        interfaces=["OnOff", "Online"],
+        on=False,
+        online=True,
+    )
+    await setup_entry(hass, device_types=TYPES)
+    state_obj = hass.states.get("switch.porch_light_relay")
+    assert state_obj is not None
+    assert state_obj.state == "off"
+    assert state_obj.attributes["device_class"] == "switch"
+
+
+async def test_new_device_signal_ignored_for_unknown_or_disconnected(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """New device signal ignored for unknown or disconnected."""
+    entry = await setup_entry(hass, device_types=TYPES)
+    before = len(hass.states.async_entity_ids("switch"))
+
+    # unknown device id: getDeviceById returns None
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "nope")
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids("switch")) == before
+
+    # SDK dropped (disconnected) while a new-device signal arrives
+    entry.runtime_data.client.sdk = None
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "outlet1")
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids("switch")) == before


### PR DESCRIPTION
## Summary

First of three PRs for controllable scrypted devices, all built on the `ScryptedDeviceEntity` base and its `_async_device_command` RPC wrapper from #47.

- **Switch**: scrypted `Switch` and `Outlet` devices with the `OnOff` interface. Device class comes from a per-type description map (`switch` or `outlet`), so no extra device lookup at construction.
- **Lock**: scrypted `Lock` devices. `lockState` `Locked`/`Unlocked`/`Jammed` map to locked, unlocked and jammed. An unknown state reports `is_locked = None`.

State is push-confirmed rather than optimistic: after `turn_off` the switch stays on until scrypted emits the property change. Neither type is in the default device-type allowlist, so these entities only appear after users enable `Switch`, `Outlet` or `Lock` in the integration options. New-device signals that arrive while disconnected or for unknown ids are ignored instead of raising inside the dispatcher callback.

The only expected conflict with sibling PRs (#51, #54, and the cover/light/fan and vacuum/climate PRs) is the one-line `PLATFORMS` list in `__init__.py`; I will rebase as they land.

## Test plan

- [x] `pytest` — 129 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
