### PR TITLE
feat: cover, light and fan platforms for controllable scrypted devices

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -59,6 +59,9 @@ class ScryptedRuntimeData:
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.COVER,
+    Platform.FAN,
+    Platform.LIGHT,
     Platform.SENSOR,
 ]
 

--- a/custom_components/scrypted/cover.py
+++ b/custom_components/scrypted/cover.py
@@ -1,0 +1,100 @@
+"""Cover entities for scrypted Entry/Garage/WindowCovering devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityDescription,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+COVER_DEVICE_CLASSES = {
+    "Garage": CoverDeviceClass.GARAGE,
+    "Entry": CoverDeviceClass.DOOR,
+    "WindowCovering": CoverDeviceClass.SHADE,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedCoverDescription(CoverEntityDescription, ScryptedEntityDescriptionMixin):
+    """Describes a scrypted cover."""
+
+
+COVER = ScryptedCoverDescription(
+    key="cover",
+    name=None,
+    interface=ScryptedInterface.Entry.value,
+    state_property="entryOpen",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted covers."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedCover]:
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None or (device.type or "") not in COVER_DEVICE_CLASSES:
+            return []
+        if not device_matches(client, device_id, COVER.interface):
+            return []
+        return [ScryptedCover(client, config_entry, device_id, COVER)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedCover(ScryptedDeviceEntity, CoverEntity):
+    """Open/close control backed by scrypted Entry (+EntrySensor state)."""
+
+    entity_description: ScryptedCoverDescription
+    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+
+    def __init__(self, client, entry, device_id, description) -> None:
+        """Initialize the cover from the device type and interfaces."""
+        super().__init__(client, entry, device_id, description)
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        self._attr_device_class = COVER_DEVICE_CLASSES[device.type]
+        self._has_sensor = ScryptedInterface.EntrySensor.value in (
+            device.interfaces or []
+        )
+        self._attr_assumed_state = not self._has_sensor
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return whether the cover is closed, or None without a sensor or when jammed."""
+        if not self._has_sensor:
+            return None
+        value = self.raw_value
+        if value is None or value == "jammed":
+            return None
+        return not value
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover via the Entry interface."""
+        await self._async_device_command("openEntry")
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover via the Entry interface."""
+        await self._async_device_command("closeEntry")

--- a/custom_components/scrypted/fan.py
+++ b/custom_components/scrypted/fan.py
@@ -1,0 +1,133 @@
+"""Fan entities for scrypted Fan devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.fan import (
+    FanEntity,
+    FanEntityDescription,
+    FanEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedFanDescription(FanEntityDescription, ScryptedEntityDescriptionMixin):
+    """Describes a scrypted fan."""
+
+
+FAN = ScryptedFanDescription(
+    key="fan",
+    name=None,
+    interface=ScryptedInterface.Fan.value,
+    state_property="fan",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted fans."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedFan]:
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None or device.type != "Fan":
+            return []
+        if not device_matches(client, device_id, FAN.interface):
+            return []
+        return [ScryptedFan(client, config_entry, device_id, FAN)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedFan(ScryptedDeviceEntity, FanEntity):
+    """Speed/preset control backed by scrypted FanStatus."""
+
+    entity_description: ScryptedFanDescription
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, client, entry, device_id, description) -> None:
+        """Initialize the fan, capturing preset modes from the initial FanStatus."""
+        super().__init__(client, entry, device_id, description)
+        status = self.raw_value or {}
+        modes = status.get("availableModes") or []
+        if modes:
+            self._attr_preset_modes = list(modes)
+            self._attr_supported_features |= FanEntityFeature.PRESET_MODE
+        self._last_speed: int | None = status.get("speed") or None
+
+    @property
+    def _status(self) -> dict:
+        return self.raw_value or {}
+
+    @property
+    def _max_speed(self) -> int:
+        return self._status.get("maxSpeed") or 1
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the current speed as a percentage of maxSpeed."""
+        speed = self._status.get("speed")
+        return None if speed is None else min(100, round(speed * 100 / self._max_speed))
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the active fan mode."""
+        return self._status.get("mode")
+
+    @callback
+    def _handle_device_update(self, event_details: dict, value: Any) -> None:
+        if self._status.get("speed"):
+            self._last_speed = self._status["speed"]
+        super()._handle_device_update(event_details, value)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Scale the percentage to the device speed range and set it."""
+        speed = round(percentage * self._max_speed / 100)
+        await self._async_device_command("setFan", {"speed": speed})
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the fan mode."""
+        await self._async_device_command("setFan", {"mode": preset_mode})
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan using the requested or last known speed or mode."""
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+        elif preset_mode is None:
+            await self._async_device_command(
+                "setFan", {"speed": self._last_speed or self._max_speed}
+            )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan by setting speed to zero."""
+        await self._async_device_command("setFan", {"speed": 0})

--- a/custom_components/scrypted/light.py
+++ b/custom_components/scrypted/light.py
@@ -1,0 +1,185 @@
+"""Light entities for scrypted Light devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HS_COLOR,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+    LightEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedLightDescription(LightEntityDescription, ScryptedEntityDescriptionMixin):
+    """Describes a scrypted light."""
+
+
+LIGHT = ScryptedLightDescription(
+    key="light",
+    name=None,
+    interface=ScryptedInterface.OnOff.value,
+    state_property="on",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted lights."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedLight]:
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None or device.type != "Light":
+            return []
+        if not device_matches(client, device_id, LIGHT.interface):
+            return []
+        return [ScryptedLight(client, config_entry, device_id, LIGHT)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedLight(ScryptedDeviceEntity, LightEntity):
+    """OnOff/Brightness/color control for scrypted lights."""
+
+    entity_description: ScryptedLightDescription
+
+    def __init__(self, client, entry, device_id, description) -> None:
+        """Initialize the light with color modes derived from its interfaces."""
+        super().__init__(client, entry, device_id, description)
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        interfaces = set(device.interfaces or [])
+        modes: set[ColorMode] = set()
+        if ScryptedInterface.ColorSettingHsv.value in interfaces:
+            modes.add(ColorMode.HS)
+        elif ScryptedInterface.ColorSettingRgb.value in interfaces:
+            modes.add(ColorMode.RGB)
+        if ScryptedInterface.ColorSettingTemperature.value in interfaces:
+            modes.add(ColorMode.COLOR_TEMP)
+        if not modes:
+            modes = (
+                {ColorMode.BRIGHTNESS}
+                if ScryptedInterface.Brightness.value in interfaces
+                else {ColorMode.ONOFF}
+            )
+        self._attr_supported_color_modes = modes
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to updates and fetch the color temperature range."""
+        await super().async_added_to_hass()
+        if ColorMode.COLOR_TEMP not in self._attr_supported_color_modes:
+            return
+        try:
+            self._attr_max_color_temp_kelvin = round(
+                await self.device.getTemperatureMaxK()
+            )
+            self._attr_min_color_temp_kelvin = round(
+                await self.device.getTemperatureMinK()
+            )
+        except Exception:  # noqa: BLE001 - fall back to HA default range
+            _LOGGER.debug(
+                "kelvin range fetch failed for %s", self.device_id, exc_info=True
+            )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the light is on."""
+        return self.raw_value
+
+    @property
+    def brightness(self) -> int | None:
+        """Return the brightness on the 0-255 scale."""
+        device = self.device
+        value = device.brightness if device else None
+        return None if value is None else round(value * 255 / 100)
+
+    @property
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature in kelvin."""
+        device = self.device
+        value = device.colorTemperature if device else None
+        return None if value is None else round(value)
+
+    @property
+    def hs_color(self) -> tuple[float, float] | None:
+        """Return the hue/saturation color, or None if not reported."""
+        device = self.device
+        hsv = (device.hsv if device else None) or {}
+        if hsv.get("h") is None:
+            return None
+        return (hsv["h"], (hsv.get("s") or 0) * 100)
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the RGB color, or None if not reported."""
+        device = self.device
+        rgb = (device.rgb if device else None) or {}
+        if rgb.get("r") is None:
+            return None
+        return (rgb["r"], rgb.get("g") or 0, rgb.get("b") or 0)
+
+    @property
+    def color_mode(self) -> ColorMode:
+        """Return the active color mode, preferring color while saturated."""
+        modes = self._attr_supported_color_modes
+        if len(modes) == 1:
+            return next(iter(modes))
+        # temp + one color mode: report color while saturated, else temp
+        if ColorMode.HS in modes:
+            hs = self.hs_color
+            saturated = bool(hs and hs[1])
+        else:
+            rgb = self.rgb_color
+            saturated = bool(rgb and len(set(rgb)) > 1)
+        if saturated:
+            return ColorMode.HS if ColorMode.HS in modes else ColorMode.RGB
+        return ColorMode.COLOR_TEMP
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light and apply any requested brightness or color."""
+        await self._async_device_command("turnOn")
+        if ATTR_BRIGHTNESS in kwargs:
+            await self._async_device_command(
+                "setBrightness", round(kwargs[ATTR_BRIGHTNESS] * 100 / 255)
+            )
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            await self._async_device_command(
+                "setColorTemperature", kwargs[ATTR_COLOR_TEMP_KELVIN]
+            )
+        if ATTR_HS_COLOR in kwargs:
+            hue, saturation = kwargs[ATTR_HS_COLOR]
+            device = self.device
+            value = ((device.hsv if device else None) or {}).get("v") or 1
+            await self._async_device_command("setHsv", hue, saturation / 100, value)
+        if ATTR_RGB_COLOR in kwargs:
+            await self._async_device_command("setRgb", *kwargs[ATTR_RGB_COLOR])
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the light."""
+        await self._async_device_command("turnOff")

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,0 +1,57 @@
+"""Tests for scrypted covers."""
+
+import copy
+
+from tests.conftest import setup_entry
+
+TYPES = ["Camera", "Doorbell", "Garage", "Entry", "WindowCovering"]
+
+
+async def test_garage_discovered_with_state(hass, fake_sdk, enable_custom_integrations):
+    """Garage discovered with state."""
+    await setup_entry(hass, device_types=TYPES)
+    state = hass.states.get("cover.garage_door")
+    assert state is not None
+    assert state.state == "closed"
+    assert state.attributes["device_class"] == "garage"
+
+    fake_sdk.systemManager.set_property("garage1", "entryOpen", True)
+    await hass.async_block_till_done()
+    assert hass.states.get("cover.garage_door").state == "open"
+
+    # jammed reads as unknown, not open/closed
+    fake_sdk.systemManager.set_property("garage1", "entryOpen", "jammed")
+    await hass.async_block_till_done()
+    assert hass.states.get("cover.garage_door").state == "unknown"
+
+
+async def test_cover_commands(hass, fake_sdk, enable_custom_integrations):
+    """Cover commands."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("garage1")
+
+    await hass.services.async_call(
+        "cover", "open_cover", {"entity_id": "cover.garage_door"}, blocking=True
+    )
+    device.openEntry.assert_awaited_once()
+
+    await hass.services.async_call(
+        "cover", "close_cover", {"entity_id": "cover.garage_door"}, blocking=True
+    )
+    device.closeEntry.assert_awaited_once()
+
+
+async def test_stateless_cover_assumed(
+    hass, fake_sdk, system_state, enable_custom_integrations
+):
+    """Stateless cover assumed."""
+    # a gate with Entry but no EntrySensor
+    system_state["gate1"] = copy.deepcopy(system_state["garage1"])
+    system_state["gate1"]["name"] = {"value": "Front Gate"}
+    system_state["gate1"]["type"] = {"value": "Entry"}
+    system_state["gate1"]["interfaces"] = {"value": ["Entry", "Online"]}
+    await setup_entry(hass, device_types=TYPES)
+    state = hass.states.get("cover.front_gate")
+    assert state is not None
+    assert state.state == "unknown"
+    assert state.attributes.get("assumed_state") is True

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,146 @@
+"""Tests for scrypted fans."""
+
+from tests.conftest import setup_entry
+
+TYPES = ["Camera", "Doorbell", "Fan"]
+
+
+async def test_fan_discovered_with_speed_and_presets(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Fan discovered with speed and presets."""
+    await setup_entry(hass, device_types=TYPES)
+    state = hass.states.get("fan.attic_fan")
+    assert state is not None
+    assert state.state == "on"  # speed 2 of 4
+    assert state.attributes["percentage"] == 50
+    assert state.attributes["preset_modes"] == ["Manual", "Auto"]
+    assert state.attributes["preset_mode"] == "Manual"
+
+
+async def test_fan_commands(hass, fake_sdk, enable_custom_integrations):
+    """Fan commands."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("fan1")
+
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": "fan.attic_fan", "percentage": 75},
+        blocking=True,
+    )
+    device.setFan.assert_awaited_with({"speed": 3})
+
+    await hass.services.async_call(
+        "fan", "turn_off", {"entity_id": "fan.attic_fan"}, blocking=True
+    )
+    device.setFan.assert_awaited_with({"speed": 0})
+
+    # turn_on restores the last observed non-zero speed
+    fake_sdk.systemManager.set_property(
+        "fan1",
+        "fan",
+        {
+            "speed": 0,
+            "maxSpeed": 4,
+            "mode": "Manual",
+            "availableModes": ["Manual", "Auto"],
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.services.async_call(
+        "fan", "turn_on", {"entity_id": "fan.attic_fan"}, blocking=True
+    )
+    device.setFan.assert_awaited_with({"speed": 2})
+
+    await hass.services.async_call(
+        "fan",
+        "set_preset_mode",
+        {"entity_id": "fan.attic_fan", "preset_mode": "Auto"},
+        blocking=True,
+    )
+    device.setFan.assert_awaited_with({"mode": "Auto"})
+
+
+async def test_fan_turn_on_with_preset_mode(hass, fake_sdk, enable_custom_integrations):
+    """turn_on with a preset_mode argument sets the mode without forcing a speed."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("fan1")
+
+    await hass.services.async_call(
+        "fan",
+        "turn_on",
+        {"entity_id": "fan.attic_fan", "preset_mode": "Auto"},
+        blocking=True,
+    )
+    device.setFan.assert_awaited_with({"mode": "Auto"})
+
+
+async def test_fan_turn_on_with_percentage(hass, fake_sdk, enable_custom_integrations):
+    """turn_on with a percentage argument sets the speed directly."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("fan1")
+
+    await hass.services.async_call(
+        "fan",
+        "turn_on",
+        {"entity_id": "fan.attic_fan", "percentage": 25},
+        blocking=True,
+    )
+    device.setFan.assert_awaited_with({"speed": 1})
+
+
+async def test_fan_percentage_clamped_when_maxspeed_missing(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """A pushed FanStatus missing maxSpeed (defaults to 1) must not exceed 100%."""
+    await setup_entry(hass, device_types=TYPES)
+
+    fake_sdk.systemManager.set_property("fan1", "fan", {"speed": 2})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("fan.attic_fan")
+    assert state is not None
+    assert state.attributes["percentage"] == 100
+
+
+async def test_fan_turn_on_remembers_speed_from_push_update(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """A push update carrying a non-zero speed is remembered for turn_on."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("fan1")
+
+    fake_sdk.systemManager.set_property(
+        "fan1",
+        "fan",
+        {
+            "speed": 3,
+            "maxSpeed": 4,
+            "mode": "Manual",
+            "availableModes": ["Manual", "Auto"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "fan", "turn_off", {"entity_id": "fan.attic_fan"}, blocking=True
+    )
+    device.setFan.assert_awaited_with({"speed": 0})
+
+    fake_sdk.systemManager.set_property(
+        "fan1",
+        "fan",
+        {
+            "speed": 0,
+            "maxSpeed": 4,
+            "mode": "Manual",
+            "availableModes": ["Manual", "Auto"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "fan", "turn_on", {"entity_id": "fan.attic_fan"}, blocking=True
+    )
+    device.setFan.assert_awaited_with({"speed": 3})

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,159 @@
+"""Tests for scrypted lights."""
+
+import copy
+
+from tests.conftest import setup_entry
+
+TYPES = ["Camera", "Doorbell", "Light"]
+
+
+async def test_light_discovered_with_modes_and_range(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Light discovered with modes and range."""
+    await setup_entry(hass, device_types=TYPES)
+    state = hass.states.get("light.desk_light")
+    assert state is not None
+    assert state.state == "off"
+    assert sorted(state.attributes["supported_color_modes"]) == ["color_temp", "hs"]
+    assert state.attributes["max_color_temp_kelvin"] == 6500
+    assert state.attributes["min_color_temp_kelvin"] == 2000
+
+
+async def test_light_state_attributes_when_on(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Light state attributes when on."""
+    await setup_entry(hass, device_types=TYPES)
+    fake_sdk.systemManager.set_property("light1", "on", True)
+    await hass.async_block_till_done()
+    state = hass.states.get("light.desk_light")
+    assert state.state == "on"
+    assert state.attributes["brightness"] == 128  # 50% -> 255 scale
+    assert state.attributes["color_mode"] == "hs"  # hsv saturation 0.5 > 0
+    assert state.attributes["hs_color"] == (120, 50.0)
+
+    # desaturated -> reports color temp
+    fake_sdk.systemManager.set_property("light1", "hsv", {"h": 0, "s": 0, "v": 1})
+    await hass.async_block_till_done()
+    state = hass.states.get("light.desk_light")
+    assert state.attributes["color_mode"] == "color_temp"
+    assert state.attributes["color_temp_kelvin"] == 3000
+
+    # missing hsv -> hs_color is None and color_mode falls back to color_temp
+    fake_sdk.systemManager.set_property("light1", "hsv", None)
+    await hass.async_block_till_done()
+    entity = hass.data["entity_components"]["light"].get_entity("light.desk_light")
+    assert entity.hs_color is None
+    state = hass.states.get("light.desk_light")
+    assert state.attributes["color_mode"] == "color_temp"
+
+
+async def test_light_commands(hass, fake_sdk, enable_custom_integrations):
+    """Light commands."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("light1")
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.desk_light", "brightness": 255, "hs_color": [240, 100]},
+        blocking=True,
+    )
+    device.turnOn.assert_awaited_once()
+    device.setBrightness.assert_awaited_once_with(100)
+    device.setHsv.assert_awaited_once_with(240, 1.0, 1)
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.desk_light", "color_temp_kelvin": 4000},
+        blocking=True,
+    )
+    device.setColorTemperature.assert_awaited_once_with(4000)
+
+    await hass.services.async_call(
+        "light", "turn_off", {"entity_id": "light.desk_light"}, blocking=True
+    )
+    device.turnOff.assert_awaited_once()
+
+
+async def test_onoff_only_light_and_kelvin_failure(
+    hass, fake_sdk, system_state, enable_custom_integrations
+):
+    """Onoff only light and kelvin failure."""
+    system_state["light2"] = copy.deepcopy(system_state["light1"])
+    system_state["light2"]["name"] = {"value": "Plain Bulb"}
+    system_state["light2"]["interfaces"] = {"value": ["OnOff", "Online"]}
+    fake_sdk.systemManager.getDeviceById(
+        "light1"
+    ).getTemperatureMaxK.side_effect = RuntimeError("nope")
+    await setup_entry(hass, device_types=TYPES)
+
+    plain = hass.states.get("light.plain_bulb")
+    assert plain.attributes["supported_color_modes"] == ["onoff"]
+    # kelvin fetch failure falls back to HA defaults without breaking setup
+    desk = hass.states.get("light.desk_light")
+    assert desk is not None
+
+
+async def test_rgb_light_color_mode_and_command(
+    hass, fake_sdk, system_state, enable_custom_integrations
+):
+    """Rgb light color mode and command."""
+    system_state["light3"] = copy.deepcopy(system_state["light1"])
+    system_state["light3"]["name"] = {"value": "Rgb Strip"}
+    system_state["light3"]["interfaces"] = {
+        "value": ["OnOff", "ColorSettingRgb", "Online"]
+    }
+    del system_state["light3"]["hsv"]
+    system_state["light3"]["rgb"] = {"value": {"r": 255, "g": 0, "b": 0}}
+    system_state["light3"]["on"] = {"value": True}
+    await setup_entry(hass, device_types=TYPES)
+
+    state = hass.states.get("light.rgb_strip")
+    assert state is not None
+    assert state.attributes["supported_color_modes"] == ["rgb"]
+    assert state.attributes["color_mode"] == "rgb"
+    assert state.attributes["rgb_color"] == (255, 0, 0)
+
+    device = fake_sdk.systemManager.getDeviceById("light3")
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.rgb_strip", "rgb_color": [10, 20, 30]},
+        blocking=True,
+    )
+    device.setRgb.assert_awaited_once_with(10, 20, 30)
+
+    # missing rgb -> rgb_color attribute is None
+    fake_sdk.systemManager.set_property("light3", "rgb", None)
+    await hass.async_block_till_done()
+    state = hass.states.get("light.rgb_strip")
+    assert state.attributes["rgb_color"] is None
+
+
+async def test_rgb_and_temp_light_color_mode(
+    hass, fake_sdk, system_state, enable_custom_integrations
+):
+    """A light with both ColorSettingRgb and ColorSettingTemperature (no Hsv)."""
+    system_state["light4"] = copy.deepcopy(system_state["light1"])
+    system_state["light4"]["name"] = {"value": "Rgb Temp Strip"}
+    system_state["light4"]["interfaces"] = {
+        "value": ["OnOff", "ColorSettingRgb", "ColorSettingTemperature", "Online"]
+    }
+    del system_state["light4"]["hsv"]
+    system_state["light4"]["rgb"] = {"value": {"r": 255, "g": 0, "b": 0}}
+    system_state["light4"]["colorTemperature"] = {"value": 3000}
+    system_state["light4"]["on"] = {"value": True}
+    await setup_entry(hass, device_types=TYPES)
+
+    state = hass.states.get("light.rgb_temp_strip")
+    assert state is not None
+    assert sorted(state.attributes["supported_color_modes"]) == ["color_temp", "rgb"]
+    assert state.attributes["color_mode"] == "rgb"
+
+    fake_sdk.systemManager.set_property("light4", "rgb", {"r": 200, "g": 200, "b": 200})
+    await hass.async_block_till_done()
+    state = hass.states.get("light.rgb_temp_strip")
+    assert state.attributes["color_mode"] == "color_temp"


### PR DESCRIPTION
## Summary

Second controllable-devices PR, on the shared `ScryptedDeviceEntity` base from #47. None of these types is in the default device-type allowlist; users opt in through the integration options.

- **Cover**: scrypted `Entry` devices. `Garage`, `Entry` and `WindowCovering` types map to the garage, door and shade device classes. Without an `EntrySensor` the cover is `assumed_state` with `is_closed = None`; a `jammed` value reports unknown.
- **Light**: `OnOff` lights with brightness, color temperature, HS and RGB where the device advertises those interfaces. HSV is preferred over RGB when both exist. With color temperature plus a color mode, `color_mode` reports the color mode only while the color is saturated, otherwise color temperature. The Kelvin range comes from `getTemperatureMaxK`/`MinK` on add, falling back to HA defaults if that fails. `turn_on` calls `turnOn` first, then applies brightness, temperature and color in sequence.
- **Fan**: `Fan` devices with speed percentage and preset modes from `FanStatus`. `turn_on` with no arguments restores the last observed non-zero speed, falling back to `maxSpeed`.

## Known follow-up

The fan's `availableModes` are captured at entity construction, so a fan whose `FanStatus` populates later never gains preset-mode support until reload. Tracked in the docs PR's TODO.

## Test plan

- [x] `pytest` — 135 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
