### PR TITLE
feat: vacuum and climate platforms for controllable scrypted devices

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -59,7 +59,9 @@ class ScryptedRuntimeData:
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.CLIMATE,
     Platform.SENSOR,
+    Platform.VACUUM,
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/scrypted/climate.py
+++ b/custom_components/scrypted/climate.py
@@ -1,0 +1,182 @@
+"""Climate entities for scrypted Thermostat devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    ClimateEntity,
+    ClimateEntityDescription,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+SCRYPTED_TO_HVAC = {
+    "Off": HVACMode.OFF,
+    "Heat": HVACMode.HEAT,
+    "Cool": HVACMode.COOL,
+    "HeatCool": HVACMode.HEAT_COOL,
+    "Auto": HVACMode.AUTO,
+    "FanOnly": HVACMode.FAN_ONLY,
+    "Dry": HVACMode.DRY,
+}
+HVAC_TO_SCRYPTED = {value: key for key, value in SCRYPTED_TO_HVAC.items()}
+ACTIVE_TO_ACTION = {
+    "Off": HVACAction.IDLE,
+    "Heat": HVACAction.HEATING,
+    "Cool": HVACAction.COOLING,
+    "Dry": HVACAction.DRYING,
+    "FanOnly": HVACAction.FAN,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedClimateDescription(
+    ClimateEntityDescription, ScryptedEntityDescriptionMixin
+):
+    """Describes a scrypted thermostat."""
+
+
+CLIMATE = ScryptedClimateDescription(
+    key="climate",
+    name=None,
+    interface=ScryptedInterface.TemperatureSetting.value,
+    state_property="temperatureSetting",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted thermostats."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedThermostat]:
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None or device.type != "Thermostat":
+            return []
+        if not device_matches(client, device_id, CLIMATE.interface):
+            return []
+        return [ScryptedThermostat(client, config_entry, device_id, CLIMATE)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedThermostat(ScryptedDeviceEntity, ClimateEntity):
+    """Thermostat control backed by scrypted TemperatureSetting."""
+
+    entity_description: ScryptedClimateDescription
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+    @property
+    def _setting(self) -> dict:
+        return self.raw_value or {}
+
+    @property
+    def supported_features(self) -> ClimateEntityFeature:
+        """Report ranged or single setpoint support based on the current setpoint shape."""
+        features = ClimateEntityFeature.TURN_OFF
+        if isinstance(self._setting.get("setpoint"), (list, tuple)):
+            features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        else:
+            features |= ClimateEntityFeature.TARGET_TEMPERATURE
+        return features
+
+    @property
+    def hvac_modes(self) -> list[HVACMode]:
+        """Translate scrypted availableModes to HVAC modes, defaulting to OFF."""
+        modes = [
+            SCRYPTED_TO_HVAC[mode]
+            for mode in self._setting.get("availableModes") or []
+            if mode in SCRYPTED_TO_HVAC
+        ]
+        return modes or [HVACMode.OFF]
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return the current scrypted mode as an HVAC mode."""
+        mode = self._setting.get("mode")
+        return SCRYPTED_TO_HVAC.get(mode) if mode is not None else None
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current scrypted activeMode as an HVAC action."""
+        active = self._setting.get("activeMode")
+        return ACTIVE_TO_ACTION.get(active) if active is not None else None
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the single setpoint, or None when the setpoint is a range."""
+        setpoint = self._setting.get("setpoint")
+        return None if isinstance(setpoint, (list, tuple)) else setpoint
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Return the lower bound of a ranged setpoint."""
+        setpoint = self._setting.get("setpoint")
+        return setpoint[0] if isinstance(setpoint, (list, tuple)) else None
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Return the upper bound of a ranged setpoint."""
+        setpoint = self._setting.get("setpoint")
+        return setpoint[1] if isinstance(setpoint, (list, tuple)) else None
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the Thermometer reading."""
+        device = self.device
+        return device.temperature if device else None
+
+    @property
+    def current_humidity(self) -> float | None:
+        """Return the HumiditySensor reading."""
+        device = self.device
+        return device.humidity if device else None
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set the scrypted thermostat mode."""
+        await self._async_device_command(
+            "setTemperature", {"mode": HVAC_TO_SCRYPTED[hvac_mode]}
+        )
+
+    async def async_turn_off(self) -> None:
+        """Turn the thermostat off."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Send a single or ranged setpoint and optional mode to the thermostat."""
+        command: dict[str, Any] = {}
+        if ATTR_TARGET_TEMP_LOW in kwargs and ATTR_TARGET_TEMP_HIGH in kwargs:
+            command["setpoint"] = [
+                kwargs[ATTR_TARGET_TEMP_LOW],
+                kwargs[ATTR_TARGET_TEMP_HIGH],
+            ]
+        elif ATTR_TEMPERATURE in kwargs:
+            command["setpoint"] = kwargs[ATTR_TEMPERATURE]
+        if kwargs.get(ATTR_HVAC_MODE) in HVAC_TO_SCRYPTED:
+            command["mode"] = HVAC_TO_SCRYPTED[kwargs[ATTR_HVAC_MODE]]
+        if command:
+            await self._async_device_command("setTemperature", command)

--- a/custom_components/scrypted/vacuum.py
+++ b/custom_components/scrypted/vacuum.py
@@ -1,0 +1,115 @@
+"""Vacuum entities for scrypted Vacuum devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scrypted_sdk import ScryptedInterface
+
+from homeassistant.components.vacuum import (
+    StateVacuumEntity,
+    StateVacuumEntityDescription,
+    VacuumActivity,
+    VacuumEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import (
+    ScryptedDeviceEntity,
+    ScryptedEntityDescriptionMixin,
+    async_setup_scrypted_platform,
+    device_matches,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScryptedVacuumDescription(
+    StateVacuumEntityDescription, ScryptedEntityDescriptionMixin
+):
+    """Describes a scrypted vacuum."""
+
+
+VACUUM = ScryptedVacuumDescription(
+    key="vacuum",
+    name=None,
+    interface=ScryptedInterface.StartStop.value,
+    state_property="running",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scrypted vacuums."""
+    client = config_entry.runtime_data.client
+
+    def _discover(device_id: str) -> list[ScryptedVacuum]:
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        if device is None or device.type != "Vacuum":
+            return []
+        if not device_matches(client, device_id, VACUUM.interface):
+            return []
+        return [ScryptedVacuum(client, config_entry, device_id, VACUUM)]
+
+    await async_setup_scrypted_platform(
+        hass, config_entry, async_add_entities, _discover
+    )
+
+
+class ScryptedVacuum(ScryptedDeviceEntity, StateVacuumEntity):
+    """StartStop/Pause/Dock control for scrypted vacuums."""
+
+    entity_description: ScryptedVacuumDescription
+
+    def __init__(self, client, entry, device_id, description) -> None:
+        """Derive supported features from the device's Pause/Dock interfaces."""
+        super().__init__(client, entry, device_id, description)
+        device = client.sdk.systemManager.getDeviceById(device_id)
+        interfaces = set(device.interfaces or [])
+        features = (
+            VacuumEntityFeature.START
+            | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.STATE
+        )
+        self._has_pause = ScryptedInterface.Pause.value in interfaces
+        if self._has_pause:
+            features |= VacuumEntityFeature.PAUSE
+        if ScryptedInterface.Dock.value in interfaces:
+            features |= VacuumEntityFeature.RETURN_HOME
+        self._attr_supported_features = features
+
+    @property
+    def activity(self) -> VacuumActivity | None:
+        """Map running/paused/docked properties to a VacuumActivity."""
+        device = self.device
+        if device is None:
+            return None
+        if device.running:
+            return VacuumActivity.PAUSED if device.paused else VacuumActivity.CLEANING
+        if device.docked:
+            return VacuumActivity.DOCKED
+        return VacuumActivity.IDLE
+
+    async def async_start(self) -> None:
+        """Resume if paused, otherwise start cleaning."""
+        device = self.device
+        if self._has_pause and device is not None and device.paused:
+            await self._async_device_command("resume")
+            return
+        await self._async_device_command("start")
+
+    async def async_stop(self, **kwargs) -> None:
+        """Stop cleaning."""
+        await self._async_device_command("stop")
+
+    async def async_pause(self) -> None:
+        """Pause cleaning."""
+        await self._async_device_command("pause")
+
+    async def async_return_to_base(self, **kwargs) -> None:
+        """Send the vacuum back to its dock."""
+        await self._async_device_command("dock")

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,128 @@
+"""Tests for scrypted thermostats."""
+
+from tests.conftest import setup_entry
+
+TYPES = ["Camera", "Doorbell", "Thermostat"]
+
+
+async def test_thermostat_discovered_with_state(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Thermostat discovered with state."""
+    await setup_entry(hass, device_types=TYPES)
+    state = hass.states.get("climate.hallway_thermostat")
+    assert state is not None
+    assert state.state == "heat"
+    assert state.attributes["hvac_modes"] == ["off", "heat", "cool", "heat_cool"]
+    assert state.attributes["hvac_action"] == "heating"
+    assert state.attributes["temperature"] == 21
+    assert state.attributes["current_temperature"] == 20
+    assert state.attributes["current_humidity"] == 40
+
+
+async def test_thermostat_range_setpoint(hass, fake_sdk, enable_custom_integrations):
+    """Thermostat range setpoint."""
+    fake_sdk.systemManager.systemState["thermo1"]["temperatureSetting"] = {
+        "value": {
+            "availableModes": ["Off", "HeatCool"],
+            "mode": "HeatCool",
+            "activeMode": "Cool",
+            "setpoint": [19, 24],
+        }
+    }
+    await setup_entry(hass, device_types=TYPES)
+    state = hass.states.get("climate.hallway_thermostat")
+    assert state.attributes["target_temp_low"] == 19
+    assert state.attributes["target_temp_high"] == 24
+    assert state.attributes["hvac_action"] == "cooling"
+
+
+async def test_thermostat_mode_and_action_absent(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Thermostat reports unknown mode and no action when scrypted omits them."""
+    fake_sdk.systemManager.systemState["thermo1"]["temperatureSetting"] = {
+        "value": {"availableModes": ["Off", "Heat"], "setpoint": 21}
+    }
+    await setup_entry(hass, device_types=TYPES)
+    state = hass.states.get("climate.hallway_thermostat")
+    assert state.state == "unknown"
+    assert state.attributes.get("hvac_action") is None
+
+
+async def test_thermostat_commands(hass, fake_sdk, enable_custom_integrations):
+    """Thermostat commands."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("thermo1")
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.hallway_thermostat", "temperature": 22.5},
+        blocking=True,
+    )
+    device.setTemperature.assert_awaited_with({"setpoint": 22.5})
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": "climate.hallway_thermostat", "hvac_mode": "cool"},
+        blocking=True,
+    )
+    device.setTemperature.assert_awaited_with({"mode": "Cool"})
+
+
+async def test_thermostat_turn_off(hass, fake_sdk, enable_custom_integrations):
+    """Thermostat turn off."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("thermo1")
+
+    await hass.services.async_call(
+        "climate",
+        "turn_off",
+        {"entity_id": "climate.hallway_thermostat"},
+        blocking=True,
+    )
+    device.setTemperature.assert_awaited_with({"mode": "Off"})
+
+
+async def test_thermostat_set_temperature_with_hvac_mode(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Thermostat set temperature with hvac mode."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("thermo1")
+
+    entity = hass.data["entity_components"]["climate"].get_entity(
+        "climate.hallway_thermostat"
+    )
+    await entity.async_set_temperature(temperature=23, hvac_mode="cool")
+    device.setTemperature.assert_awaited_with({"setpoint": 23, "mode": "Cool"})
+
+    device.setTemperature.reset_mock()
+    await entity.async_set_temperature()
+    device.setTemperature.assert_not_awaited()
+
+
+async def test_thermostat_range_command(hass, fake_sdk, enable_custom_integrations):
+    """Thermostat range command."""
+    fake_sdk.systemManager.systemState["thermo1"]["temperatureSetting"] = {
+        "value": {
+            "availableModes": ["Off", "HeatCool"],
+            "mode": "HeatCool",
+            "setpoint": [19, 24],
+        }
+    }
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("thermo1")
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {
+            "entity_id": "climate.hallway_thermostat",
+            "target_temp_low": 18,
+            "target_temp_high": 25,
+        },
+        blocking=True,
+    )
+    device.setTemperature.assert_awaited_with({"setpoint": [18, 25]})

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -1,0 +1,74 @@
+"""Tests for scrypted vacuums."""
+
+from tests.conftest import setup_entry
+
+TYPES = ["Camera", "Doorbell", "Vacuum"]
+
+
+async def test_vacuum_activity_states(hass, fake_sdk, enable_custom_integrations):
+    """Vacuum activity states."""
+    await setup_entry(hass, device_types=TYPES)
+    assert hass.states.get("vacuum.robo_vac").state == "docked"
+
+    fake_sdk.systemManager.set_property("vac1", "docked", False)
+    fake_sdk.systemManager.set_property("vac1", "running", True)
+    await hass.async_block_till_done()
+    assert hass.states.get("vacuum.robo_vac").state == "cleaning"
+
+    fake_sdk.systemManager.set_property("vac1", "paused", True)
+    await hass.async_block_till_done()
+    assert hass.states.get("vacuum.robo_vac").state == "paused"
+
+    fake_sdk.systemManager.set_property("vac1", "running", False)
+    fake_sdk.systemManager.set_property("vac1", "paused", False)
+    await hass.async_block_till_done()
+    assert hass.states.get("vacuum.robo_vac").state == "idle"
+
+
+async def test_vacuum_commands(hass, fake_sdk, enable_custom_integrations):
+    """Vacuum commands."""
+    await setup_entry(hass, device_types=TYPES)
+    device = fake_sdk.systemManager.getDeviceById("vac1")
+
+    await hass.services.async_call(
+        "vacuum", "start", {"entity_id": "vacuum.robo_vac"}, blocking=True
+    )
+    device.start.assert_awaited_once()
+
+    await hass.services.async_call(
+        "vacuum", "pause", {"entity_id": "vacuum.robo_vac"}, blocking=True
+    )
+    device.pause.assert_awaited_once()
+
+    # start while paused resumes
+    fake_sdk.systemManager.set_property("vac1", "running", True)
+    fake_sdk.systemManager.set_property("vac1", "paused", True)
+    await hass.async_block_till_done()
+    await hass.services.async_call(
+        "vacuum", "start", {"entity_id": "vacuum.robo_vac"}, blocking=True
+    )
+    device.resume.assert_awaited_once()
+
+    await hass.services.async_call(
+        "vacuum", "stop", {"entity_id": "vacuum.robo_vac"}, blocking=True
+    )
+    device.stop.assert_awaited_once()
+
+    await hass.services.async_call(
+        "vacuum", "return_to_base", {"entity_id": "vacuum.robo_vac"}, blocking=True
+    )
+    device.dock.assert_awaited_once()
+
+
+async def test_vacuum_activity_none_when_device_gone(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Vacuum activity none when device gone."""
+    entry = await setup_entry(hass, device_types=TYPES)
+    entity = hass.data["entity_components"]["vacuum"].get_entity("vacuum.robo_vac")
+
+    entry.runtime_data.client.sdk = None
+    try:
+        assert entity.activity is None
+    finally:
+        entry.runtime_data.client.sdk = fake_sdk


### PR DESCRIPTION
## Summary

Third controllable-devices PR, on the shared `ScryptedDeviceEntity` base from #47. Neither type is in the default device-type allowlist.

- **Vacuum**: `StartStop` devices as state vacuums. `PAUSE` and `RETURN_HOME` are only advertised when the device exposes the `Pause` and `Dock` interfaces. Starting while paused issues `resume` instead of `start`.
- **Climate**: `Thermostat` devices. Scrypted `TemperatureSetting` modes map to HVAC modes (Off, Heat, Cool, HeatCool, Auto, FanOnly, Dry), with `hvac_modes` falling back to Off only when `availableModes` is empty. Supports single or ranged setpoints, plus current temperature and humidity from the `Thermometer` and `HumiditySensor` interfaces. Units are Celsius, scrypted's native unit; HA converts for display.

## Known follow-up

`supported_features` is derived from the live setpoint shape (list versus scalar) rather than from `availableModes`, so the feature flags can flip when a thermostat switches between HeatCool and a single mode. Tracked in the docs PR's TODO.

## Test plan

- [x] `pytest` — 130 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
