### PR TITLE
docs: describe all device entity platforms and record follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ in the integration options.
   intentionally not supported; use the Scrypted NVR cards for live view.
 - **Binary sensor** — motion, doorbell button, sound, occupancy, flood, entry,
   power, connectivity, tamper, charging, sleeping.
+- **Event** — object detection (`person`, `car`, … from the detector's
+  reported classes) and doorbell presses, usable as automation triggers.
+- **Sensor** — temperature, humidity, battery, illuminance, UV, CO2,
+  PM2.5/PM10, VOC, NOx, air quality.
+- **Media player** — intercom-capable devices (doorbells, two-way cameras)
+  become speaker entities: point `media_player.play_media`, TTS, or announce
+  at them to talk through the camera speaker.
+- **Switch, lock, cover, light, fan, vacuum, climate** — controllable
+  Scrypted devices of those types, once their device type is enabled in the
+  options.
+
+Scrypted NVR detection clips are also available in the Home Assistant media
+browser (camera → day → clip) and play through HA's stream component.
 
 State updates are pushed; no polling. Entities reconnect automatically if the
 server restarts.

--- a/TODO.md
+++ b/TODO.md
@@ -46,3 +46,31 @@ The credentials reauth step currently collects the panel name/icon alongside
 passwords; move those UI fields into the options flow so credential updates
 only prompt for authentication details. Once the options flow exposes these
 fields, remove them from the credentials step to reduce user confusion.
+
+## 7. NVR clips: inline playback in Chrome
+
+Clips resolve to HLS through HA's stream component, which plays inline on
+Safari/iOS, the companion apps and Chromecast, but not in Chrome/desktop
+because HA's generic media dialog lacks hls.js (core's camera media source
+only works via the camera entity's own player). Universal inline playback
+needs native MP4, and scrypted NVR cannot convert clips synchronously (only to
+FFmpegInput), so this would be an async NVR mp4-export flow: start the export
+on resolve, poll for completion, serve through the proxy.
+
+## 8. Controllable device follow-ups
+
+- Reconnect discovery gap: `ScryptedClient.async_connect` reseeds
+  `_known_ids` on reconnect, so devices added during an outage never fire
+  `SIGNAL_NEW_DEVICE` and get no entities until reload. Dispatch the signal
+  for genuinely new ids on reconnect; the platform helper dedups.
+- Climate `supported_features` flips between TARGET_TEMPERATURE and
+  TARGET_TEMPERATURE_RANGE based on the live setpoint shape and advertises
+  TURN_OFF even when "Off" is not an available mode; derive stable flags from
+  `availableModes`.
+- Fan `availableModes` is captured only at entity construction; a fan whose
+  FanStatus populates after discovery never gains PRESET_MODE.
+- `async_remove_config_entry_device` reimplements the discovery check inline
+  and lacks the HA_PLUGIN_ID loop guard; share a predicate with
+  `device_matches`.
+- PTZ support (`PanTiltZoom` interface) on cameras.
+


### PR DESCRIPTION
## Summary

Documentation for the full device-entities series. Merge this last, after the platform PRs it describes.

- README: extends the "Device entities" section (added in #50) with the event, sensor, media player and controllable-device platforms, and the NVR clips media browser.
- TODO: records the known follow-ups surfaced during review of the original branch (#43): inline clip playback in Chrome needs an async NVR MP4 export; reconnect discovery gap for devices added during an outage; climate `supported_features` should derive from `availableModes`; fan `availableModes` captured only at construction; `async_remove_config_entry_device` should share a predicate with `device_matches`; PTZ support.

Depends on #51, #52, #53, #54 and the three controllable-device PRs being merged first, otherwise the README describes platforms that are not there yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
