### PR TITLE
fix: report connectivity state and every detected object class

### DIFF
--- a/custom_components/scrypted/entity.py
+++ b/custom_components/scrypted/entity.py
@@ -28,6 +28,9 @@ from .const import (
 )
 from .hub import ScryptedClient
 
+# systemState property backing the Online interface.
+ONLINE_PROPERTY = "online"
+
 
 @dataclass(frozen=True, kw_only=True)
 class ScryptedEntityDescriptionMixin:
@@ -152,12 +155,19 @@ class ScryptedDeviceEntity(Entity):
 
     @property
     def available(self) -> bool:
-        """Return True when connected and the device is present and online."""
+        """Return True when connected and the device is present and online.
+
+        An entity whose own value is the online property stays available while
+        the device is offline, so it can report that state instead of
+        disappearing.
+        """
         if not self.client.connected:
             return False
         device = self.device
         if device is None:
             return False
+        if getattr(self.entity_description, "state_property", None) == ONLINE_PROPERTY:
+            return True
         if (
             ScryptedInterface.Online.value in (device.interfaces or [])
             and device.online is False

--- a/custom_components/scrypted/event.py
+++ b/custom_components/scrypted/event.py
@@ -14,10 +14,8 @@ from homeassistant.components.event import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import SIGNAL_CONNECTION
 from .entity import ScryptedDeviceEntity, async_setup_scrypted_platform, device_matches
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,18 +100,7 @@ class ScryptedObjectDetectionEvent(ScryptedDeviceEntity, EventEntity):
         """Register the detection listener and re-register it after reconnects."""
         await super().async_added_to_hass()
         self._register_listener()
-        # Re-register the server-side listener after reconnects.
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                SIGNAL_CONNECTION.format(self.entry.entry_id),
-                self._handle_reconnect,
-            )
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Remove the server-side detection listener."""
-        self._remove_listener()
+        self.async_on_remove(self._remove_listener)
 
     def _register_listener(self) -> None:
         if not self.client.sdk:
@@ -130,23 +117,27 @@ class ScryptedObjectDetectionEvent(ScryptedDeviceEntity, EventEntity):
             self._unregister = None
 
     @callback
-    def _handle_reconnect(self, connected: bool) -> None:
+    def _handle_connection_change(self, connected: bool) -> None:
         if connected:
-            self._remove_listener()
+            # The previous registration died with the old transport; calling
+            # removeListener on it would RPC over a closed peer.
+            self._unregister = None
             self._register_listener()
-        self.async_write_ha_state()
+        super()._handle_connection_change(connected)
 
     def _on_objects_detected(self, device, event_details: dict, data: Any) -> None:
         """Fire one event per detected class; runs on the HA loop via the engine.io read task."""
-        detections = (data or {}).get("detections") or []
+        data = data or {}
+        detection_id = data.get("detectionId")
         seen: set[str] = set()
-        for detection in detections:
+        for detection in data.get("detections") or []:
             class_name = detection.get("className")
             if not class_name or class_name == MOTION_CLASS or class_name in seen:
                 continue
             seen.add(class_name)
             if class_name not in self._attr_event_types:
-                # event_types is fixed at trigger time; extend for unknown classes
+                # _trigger_event rejects types outside event_types; learn classes
+                # the detector did not advertise up front.
                 self._attr_event_types = [*self._attr_event_types, class_name]
             self._trigger_event(
                 class_name,
@@ -154,10 +145,11 @@ class ScryptedObjectDetectionEvent(ScryptedDeviceEntity, EventEntity):
                     "label": detection.get("label"),
                     "score": detection.get("score"),
                     "zones": detection.get("zones"),
-                    "detection_id": (data or {}).get("detectionId"),
+                    "detection_id": detection_id,
                 },
             )
-        if seen:
+            # EventEntity keeps only the last event, so write per class rather
+            # than once per payload; HA forces strictly increasing timestamps.
             self.async_write_ha_state()
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -99,3 +99,23 @@ def test_binary_sensor_is_on_none_when_property_missing(fake_sdk):
     entity = ScryptedBinarySensor(client, entry, "cam1", description)
     fake_sdk.systemManager.systemState["cam1"].pop("motionDetected")
     assert entity.is_on is None
+
+
+async def test_online_sensor_reports_off_when_device_offline(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """The connectivity sensor reports off rather than going unavailable."""
+    await setup_entry(hass)
+    online = "binary_sensor.porch_front_door_cam_online"
+    assert hass.states.get(online).state == "on"
+
+    fake_sdk.systemManager.set_property("cam1", "online", False)
+    await hass.async_block_till_done()
+
+    # The sensor that reports the online property stays available and says off,
+    # while every other entity on the device goes unavailable.
+    assert hass.states.get(online).state == "off"
+    assert (
+        hass.states.get("binary_sensor.porch_front_door_cam_motion").state
+        == "unavailable"
+    )

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,5 +1,6 @@
 """Tests for scrypted event entities."""
 
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from custom_components.scrypted.const import SIGNAL_CONNECTION, SIGNAL_NEW_DEVICE
@@ -181,3 +182,58 @@ async def test_new_device_signal_unknown_id_ignored(
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all("event")) == before
+
+
+async def test_multiple_classes_each_fire_an_event(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Each class in one payload produces its own observable event."""
+    await setup_entry(hass)
+    entity_id = "event.porch_front_door_cam_object_detected"
+
+    fired: list[str] = []
+
+    @callback
+    def _track(event):
+        if event.data["entity_id"] != entity_id:
+            return
+        new_state = event.data.get("new_state")
+        if new_state:
+            fired.append(new_state.attributes["event_type"])
+
+    hass.bus.async_listen("state_changed", _track)
+
+    fake_sdk.systemManager.fire_device_event(
+        "cam1",
+        "ObjectDetector",
+        {
+            "detections": [
+                {"className": "person", "score": 0.9},
+                {"className": "car", "score": 0.8},
+            ],
+            "detectionId": "d1",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert fired == ["person", "car"]
+    assert hass.states.get(entity_id).attributes["detection_id"] == "d1"
+
+
+async def test_reconnect_reregisters_without_touching_stale_register(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """Reconnect re-registers a listener and drops the dead one untouched."""
+    entry = await setup_entry(hass)
+    manager = fake_sdk.systemManager
+    key = ("cam1", "ObjectDetector")
+    assert key in manager.device_listeners
+
+    # The transport died, so the server-side listener went with it and the old
+    # register object can no longer be used to remove anything.
+    manager.device_listeners.clear()
+
+    async_dispatcher_send(hass, SIGNAL_CONNECTION.format(entry.entry_id), True)
+    await hass.async_block_till_done()
+
+    assert key in manager.device_listeners


### PR DESCRIPTION
## Summary

Three entity-behavior bugs found while reviewing the device-entities series. Each is verified with a regression test that fails before the fix.

**The connectivity binary sensor could never report "off".** `ScryptedDeviceEntity.available` marks every entity on an offline device unavailable, which included the `online` sensor itself. So the entity whose whole purpose is reporting that a device went offline disappeared at exactly that moment, and only ever showed `on` or `unavailable`. An entity whose backing property *is* `online` is now exempt from that gate.

```
before:  online=False  ->  binary_sensor..._online = unavailable
after:   online=False  ->  binary_sensor..._online = off   (siblings still unavailable)
```

**Only the last detected class in a payload was observable.** `EventEntity` stores a single last event, so calling `_trigger_event` once per class and writing state once at the end discarded everything but the final class. A payload of `[person, car]` produced only `car`, and automations on `person` never fired. State is now written per class, which is what the method's docstring already claimed.

**The object-detection entity mismanaged its listener across reconnects.** It subscribed to `SIGNAL_CONNECTION` a second time rather than overriding the base `_handle_connection_change` hook, so each connection change wrote state twice. On reconnect it also called `removeListener()` on a register bound to the transport that had just closed, which in the SDK schedules an RPC against a killed peer. The stale register is now simply dropped, since the server-side listener died with the socket. Teardown moves to `async_on_remove`, matching how the base class handles its other subscriptions.

## Test plan

- [x] `pytest` — 175 tests, 100% coverage gate
- [x] Three new regression tests, each failing before the corresponding fix
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
