### PR TITLE
fix: stop platform discovery from crashing on a dropped connection

### DIFF
--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -43,6 +43,7 @@ from .const import (
     DEFAULT_DEVICE_TYPES,
     DOMAIN,
 )
+from .entity import exposed_device
 from .http import ScryptedView, retrieve_token
 from .hub import ScryptedClient
 from .sdk import get_base_url
@@ -358,9 +359,11 @@ async def async_remove_config_entry_device(
     The hub device and any device that would still produce entities (present
     in the scrypted system state with an allowlisted type) stay protected.
     """
-    client = config_entry.runtime_data.client
+    # HA offers device removal regardless of entry state, and runtime_data only
+    # exists while the entry is loaded.
+    data = getattr(config_entry, "runtime_data", None)
+    client = data.client if data else None
     prefix = f"{config_entry.entry_id}_"
-    allowed_types = config_entry.options.get(CONF_DEVICE_TYPES, DEFAULT_DEVICE_TYPES)
 
     for domain, identifier in device_entry.identifiers:
         if domain != DOMAIN:
@@ -370,11 +373,7 @@ async def async_remove_config_entry_device(
             return False
         if not identifier.startswith(prefix):
             continue
-        device_id = identifier.removeprefix(prefix)
-        if client is None or client.sdk is None:
-            continue
-        device = client.sdk.systemManager.getDeviceById(device_id)
-        if device is not None and (device.type or "Unknown") in allowed_types:
+        if exposed_device(client, identifier.removeprefix(prefix)) is not None:
             # Still exposed by the integration; deleting it would only have
             # it reappear on the next event or reload.
             return False

--- a/custom_components/scrypted/climate.py
+++ b/custom_components/scrypted/climate.py
@@ -26,7 +26,7 @@ from .entity import (
     ScryptedDeviceEntity,
     ScryptedEntityDescriptionMixin,
     async_setup_scrypted_platform,
-    device_matches,
+    exposed_device,
 )
 
 SCRYPTED_TO_HVAC = {
@@ -72,10 +72,12 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     def _discover(device_id: str) -> list[ScryptedThermostat]:
-        device = client.sdk.systemManager.getDeviceById(device_id)
-        if device is None or device.type != "Thermostat":
-            return []
-        if not device_matches(client, device_id, CLIMATE.interface):
+        device = exposed_device(client, device_id)
+        if (
+            device is None
+            or device.type != "Thermostat"
+            or CLIMATE.interface not in (device.interfaces or [])
+        ):
             return []
         return [ScryptedThermostat(client, config_entry, device_id, CLIMATE)]
 

--- a/custom_components/scrypted/cover.py
+++ b/custom_components/scrypted/cover.py
@@ -21,7 +21,7 @@ from .entity import (
     ScryptedDeviceEntity,
     ScryptedEntityDescriptionMixin,
     async_setup_scrypted_platform,
-    device_matches,
+    exposed_device,
 )
 
 COVER_DEVICE_CLASSES = {
@@ -53,10 +53,12 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     def _discover(device_id: str) -> list[ScryptedCover]:
-        device = client.sdk.systemManager.getDeviceById(device_id)
-        if device is None or (device.type or "") not in COVER_DEVICE_CLASSES:
-            return []
-        if not device_matches(client, device_id, COVER.interface):
+        device = exposed_device(client, device_id)
+        if (
+            device is None
+            or (device.type or "") not in COVER_DEVICE_CLASSES
+            or COVER.interface not in (device.interfaces or [])
+        ):
             return []
         return [ScryptedCover(client, config_entry, device_id, COVER)]
 

--- a/custom_components/scrypted/entity.py
+++ b/custom_components/scrypted/entity.py
@@ -46,23 +46,31 @@ class ScryptedEntityDescriptionMixin:
     value_fn: Callable[[Any], Any] = lambda value: value
 
 
-def device_matches(client: ScryptedClient, device_id: str, interface: str) -> bool:
-    """Return True if the device should produce an entity for interface.
+def exposed_device(client: ScryptedClient | None, device_id: str) -> Any:
+    """Return the DeviceProxy when this device should produce entities.
 
-    Only devices whose scrypted type is in the configured allowlist
-    (default: cameras and doorbells) are mirrored as entities.
+    A device is exposed when the connection is live, scrypted still knows the
+    device, it is not one Home Assistant itself exported to scrypted, and its
+    type is in the configured allowlist (default: cameras and doorbells).
+    Returns None otherwise, so callers never touch a dropped SDK.
     """
-    if client.sdk is None:
-        return False
+    if client is None or client.sdk is None:
+        return None
     device = client.sdk.systemManager.getDeviceById(device_id)
     if device is None:
-        return False
+        return None
     if device.pluginId == HA_PLUGIN_ID:
-        return False
+        return None
     allowed_types = client.entry.options.get(CONF_DEVICE_TYPES, DEFAULT_DEVICE_TYPES)
     if (device.type or "Unknown") not in allowed_types:
-        return False
-    return interface in (device.interfaces or [])
+        return None
+    return device
+
+
+def device_matches(client: ScryptedClient, device_id: str, interface: str) -> bool:
+    """Return True if the device should produce an entity for interface."""
+    device = exposed_device(client, device_id)
+    return device is not None and interface in (device.interfaces or [])
 
 
 async def async_setup_scrypted_platform(

--- a/custom_components/scrypted/event.py
+++ b/custom_components/scrypted/event.py
@@ -16,7 +16,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import ScryptedDeviceEntity, async_setup_scrypted_platform, device_matches
+from .entity import (
+    ScryptedDeviceEntity,
+    async_setup_scrypted_platform,
+    exposed_device,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,10 +51,11 @@ async def async_setup_entry(
 
     async def _discover(device_id: str) -> list[EventEntity]:
         entities: list[EventEntity] = []
-        device = client.sdk.systemManager.getDeviceById(device_id)
+        device = exposed_device(client, device_id)
         if device is None:
             return entities
-        if device_matches(client, device_id, ScryptedInterface.ObjectDetector.value):
+        interfaces = device.interfaces or []
+        if ScryptedInterface.ObjectDetector.value in interfaces:
             event_types = await _async_object_event_types(device)
             if event_types:
                 entities.append(
@@ -58,8 +63,9 @@ async def async_setup_entry(
                         client, config_entry, device_id, OBJECT_DETECTED, event_types
                     )
                 )
-        if device.type == "Doorbell" and device_matches(
-            client, device_id, ScryptedInterface.BinarySensor.value
+        if (
+            device.type == "Doorbell"
+            and ScryptedInterface.BinarySensor.value in interfaces
         ):
             entities.append(
                 ScryptedDoorbellEvent(client, config_entry, device_id, DOORBELL)

--- a/custom_components/scrypted/fan.py
+++ b/custom_components/scrypted/fan.py
@@ -20,7 +20,7 @@ from .entity import (
     ScryptedDeviceEntity,
     ScryptedEntityDescriptionMixin,
     async_setup_scrypted_platform,
-    device_matches,
+    exposed_device,
 )
 
 
@@ -46,10 +46,12 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     def _discover(device_id: str) -> list[ScryptedFan]:
-        device = client.sdk.systemManager.getDeviceById(device_id)
-        if device is None or device.type != "Fan":
-            return []
-        if not device_matches(client, device_id, FAN.interface):
+        device = exposed_device(client, device_id)
+        if (
+            device is None
+            or device.type != "Fan"
+            or FAN.interface not in (device.interfaces or [])
+        ):
             return []
         return [ScryptedFan(client, config_entry, device_id, FAN)]
 

--- a/custom_components/scrypted/light.py
+++ b/custom_components/scrypted/light.py
@@ -25,7 +25,7 @@ from .entity import (
     ScryptedDeviceEntity,
     ScryptedEntityDescriptionMixin,
     async_setup_scrypted_platform,
-    device_matches,
+    exposed_device,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,10 +53,12 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     def _discover(device_id: str) -> list[ScryptedLight]:
-        device = client.sdk.systemManager.getDeviceById(device_id)
-        if device is None or device.type != "Light":
-            return []
-        if not device_matches(client, device_id, LIGHT.interface):
+        device = exposed_device(client, device_id)
+        if (
+            device is None
+            or device.type != "Light"
+            or LIGHT.interface not in (device.interfaces or [])
+        ):
             return []
         return [ScryptedLight(client, config_entry, device_id, LIGHT)]
 

--- a/custom_components/scrypted/lock.py
+++ b/custom_components/scrypted/lock.py
@@ -16,7 +16,7 @@ from .entity import (
     ScryptedDeviceEntity,
     ScryptedEntityDescriptionMixin,
     async_setup_scrypted_platform,
-    device_matches,
+    exposed_device,
 )
 
 
@@ -42,12 +42,12 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     def _discover(device_id: str) -> list[ScryptedLock]:
-        if client.sdk is None:
-            return []
-        device = client.sdk.systemManager.getDeviceById(device_id)
-        if device is None or device.type != "Lock":
-            return []
-        if not device_matches(client, device_id, LOCK.interface):
+        device = exposed_device(client, device_id)
+        if (
+            device is None
+            or device.type != "Lock"
+            or LOCK.interface not in (device.interfaces or [])
+        ):
             return []
         return [ScryptedLock(client, config_entry, device_id, LOCK)]
 

--- a/custom_components/scrypted/switch.py
+++ b/custom_components/scrypted/switch.py
@@ -20,7 +20,7 @@ from .entity import (
     ScryptedDeviceEntity,
     ScryptedEntityDescriptionMixin,
     async_setup_scrypted_platform,
-    device_matches,
+    exposed_device,
 )
 
 
@@ -60,15 +60,13 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     def _discover(device_id: str) -> list[ScryptedSwitch]:
-        if client.sdk is None:
-            return []
-        device = client.sdk.systemManager.getDeviceById(device_id)
+        device = exposed_device(client, device_id)
         if device is None:
             return []
         description = SWITCH_DESCRIPTIONS.get(device.type or "")
-        if description is None:
-            return []
-        if not device_matches(client, device_id, description.interface):
+        if description is None or description.interface not in (
+            device.interfaces or []
+        ):
             return []
         return [ScryptedSwitch(client, config_entry, device_id, description)]
 

--- a/custom_components/scrypted/vacuum.py
+++ b/custom_components/scrypted/vacuum.py
@@ -20,7 +20,7 @@ from .entity import (
     ScryptedDeviceEntity,
     ScryptedEntityDescriptionMixin,
     async_setup_scrypted_platform,
-    device_matches,
+    exposed_device,
 )
 
 
@@ -48,10 +48,12 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     def _discover(device_id: str) -> list[ScryptedVacuum]:
-        device = client.sdk.systemManager.getDeviceById(device_id)
-        if device is None or device.type != "Vacuum":
-            return []
-        if not device_matches(client, device_id, VACUUM.interface):
+        device = exposed_device(client, device_id)
+        if (
+            device is None
+            or device.type != "Vacuum"
+            or VACUUM.interface not in (device.interfaces or [])
+        ):
             return []
         return [ScryptedVacuum(client, config_entry, device_id, VACUUM)]
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -6,10 +6,13 @@ from types import SimpleNamespace
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.const import CONF_HOST
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import EntityDescription
 
+from custom_components import scrypted
 from custom_components.scrypted.const import DOMAIN, SIGNAL_NEW_DEVICE
 from custom_components.scrypted.entity import (
     ScryptedDeviceEntity,
@@ -170,3 +173,47 @@ async def test_device_command_wraps_errors(hass, fake_sdk, enable_custom_integra
     ).takePicture.side_effect = HomeAssistantError("already user-friendly")
     with pytest.raises(HomeAssistantError, match="already user-friendly"):
         await entity._async_device_command("takePicture")
+
+
+async def test_new_device_while_disconnected_does_not_raise(
+    hass, fake_sdk, enable_custom_integrations
+):
+    """A new-device signal arriving after the SDK dropped is ignored quietly."""
+    entry = await setup_entry(
+        hass,
+        device_types=[
+            "Camera",
+            "Doorbell",
+            "Sensor",
+            "Thermostat",
+            "Vacuum",
+            "Fan",
+            "Light",
+            "Garage",
+            "Lock",
+            "Switch",
+            "Outlet",
+        ],
+    )
+    before = len(hass.states.async_all())
+
+    # Every platform's discovery runs on this signal; none may touch the
+    # dropped SDK.
+    entry.runtime_data.client.sdk = None
+    async_dispatcher_send(hass, SIGNAL_NEW_DEVICE.format(entry.entry_id), "thermo1")
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == before
+
+
+async def test_remove_device_without_runtime_data(hass, fake_sdk):
+    """Device removal works while the entry is not loaded."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "example"})
+    entry.add_to_hass(hass)
+    device_entry = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{entry.entry_id}_ghost")},
+    )
+    # Entry never set up, so HA never assigned runtime_data.
+    assert not hasattr(entry, "runtime_data")
+    assert await scrypted.async_remove_config_entry_device(hass, entry, device_entry)


### PR DESCRIPTION
## Summary

Five platforms crashed when a new-device signal arrived while the connection was down, and stale devices could not be deleted from an entry that had failed to set up.

**Discovery crashed on a dropped SDK.** `climate`, `cover`, `fan`, `light` and `vacuum` all did `client.sdk.systemManager.getDeviceById(...)` in their discovery closure with no guard. Since discovery runs from a dispatcher callback, the `AttributeError` surfaced as an unretrieved task exception rather than anything actionable. The existing test suite already emitted two of these at teardown on `main`; they are gone with this change.

```
AttributeError: 'NoneType' object has no attribute 'systemManager'
custom_components/scrypted/climate.py:75
```

Rather than paste the guard into five more places, discovery now shares one helper:

```python
def exposed_device(client, device_id):
    """Return the DeviceProxy when this device should produce entities."""
```

It returns `None` unless the connection is live, scrypted still knows the device, the device is not one HA exported to scrypted, and its type is in the allowlist. `device_matches()` is now defined in terms of it, so the two predicates cannot drift apart.

**This also removes a redundant lookup.** Every closure resolved the device, then called `device_matches`, which resolved it again and re-applied the checks that had just run. The type and interface tests are now a single condition over the device already in hand.

**Device removal failed when the entry was not loaded.** `async_remove_config_entry_device` read `config_entry.runtime_data` unguarded, but HA offers device removal regardless of entry state and only sets `runtime_data` while an entry is loaded. Deleting a stale device from an entry stuck in `SETUP_RETRY` raised `AttributeError` and the UI reported an unknown error. It also open-coded the allowlist check without the HA-plugin exclusion, so a device mirrored back from Home Assistant counted as "still exposed" and could never be removed.

## Test plan

- [x] `pytest` — 174 tests, 100% coverage gate
- [x] New regression test reproduces the `AttributeError` against unfixed `main`
- [x] Two pre-existing teardown errors in the suite are resolved
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
