### PR TITLE
fix: preserve options through reauth and survive a failed setup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -73,4 +73,3 @@ on resolve, poll for completion, serve through the proxy.
   and lacks the HA_PLUGIN_ID loop guard; share a predicate with
   `device_matches`.
 - PTZ support (`PanTiltZoom` interface) on cameras.
-

--- a/custom_components/scrypted/__init__.py
+++ b/custom_components/scrypted/__init__.py
@@ -289,7 +289,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             return _reauth(config_entry.data)
         raise e
 
-    hass.data.setdefault(DOMAIN, {})[token] = config_entry
     config_entry.async_on_unload(
         config_entry.add_update_listener(_async_update_listener)
     )
@@ -315,6 +314,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             configuration_url=get_base_url(config_entry.data[CONF_HOST]),
         )
 
+    # Published only once setup can no longer fail: the proxy view and the
+    # token sensor resolve entries through this mapping, and a failed setup
+    # never reaches async_unload_entry to clean it up again.
+    hass.data.setdefault(DOMAIN, {})[token] = config_entry
     config_entry.runtime_data = ScryptedRuntimeData(token=token, client=client)
 
     if config_entry.options.get(CONF_AUTO_REGISTER_RESOURCES):

--- a/custom_components/scrypted/config_flow.py
+++ b/custom_components/scrypted/config_flow.py
@@ -173,8 +173,17 @@ class ScryptedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     for entry in self.hass.config_entries.async_entries(DOMAIN)
                     if entry != config_entry and entry.unique_id == unique_id
                 ):
+                    # Keep options this form does not collect (the entity
+                    # options); let the fields it does collect win.
+                    options = dict(config_entry.options)
+                    for key in (CONF_SCRYPTED_NVR, CONF_AUTO_REGISTER_RESOURCES):
+                        if key in user_input:
+                            options[key] = user_input[key]
                     self.hass.config_entries.async_update_entry(
-                        config_entry, data=user_input, options={}, unique_id=unique_id
+                        config_entry,
+                        data=user_input,
+                        options=options,
+                        unique_id=unique_id,
                     )
                     self.hass.async_create_task(
                         self.hass.config_entries.async_reload(config_entry.entry_id)

--- a/custom_components/scrypted/hub.py
+++ b/custom_components/scrypted/hub.py
@@ -122,5 +122,9 @@ class ScryptedClient:
                 return
             except ScryptedConnectionError as err:
                 _LOGGER.debug("Scrypted reconnect failed: %s", err)
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, RECONNECT_MAX_DELAY)
+            except Exception:
+                # Anything escaping here would end the task and leave the entry
+                # offline until it is reloaded by hand.
+                _LOGGER.exception("Unexpected error reconnecting to %s", self.host)
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, RECONNECT_MAX_DELAY)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -319,3 +319,72 @@ async def test_options_flow_includes_enable_entities(hass):
     )
     assert result["type"] == "create_entry"
     assert result["data"][CONF_ENABLE_ENTITIES] is False
+
+
+async def test_reauth_preserves_entity_options(hass):
+    """Reauth keeps options its form never collects."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: EXAMPLE_HOST},
+        options={
+            CONF_AUTO_REGISTER_RESOURCES: False,
+            CONF_SCRYPTED_NVR: False,
+            CONF_ENABLE_ENTITIES: False,
+            "device_types": ["Camera", "Doorbell", "Sensor"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    init_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+            "data": {**entry.data, CONF_PASSWORD: "old"},
+        },
+    )
+    result = await hass.config_entries.flow.async_configure(
+        init_result["flow_id"], CREDENTIALS_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert entry.options["device_types"] == ["Camera", "Doorbell", "Sensor"]
+    assert entry.options[CONF_ENABLE_ENTITIES] is False
+
+
+async def test_upgrade_step_applies_its_own_fields_and_keeps_the_rest(hass):
+    """The upgrade form's own fields win; entity options survive."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: EXAMPLE_HOST},
+        options={
+            CONF_AUTO_REGISTER_RESOURCES: False,
+            CONF_SCRYPTED_NVR: False,
+            CONF_ENABLE_ENTITIES: False,
+            "device_types": ["Camera", "Doorbell", "Sensor"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    init_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+            "data": entry.data,
+        },
+    )
+    assert init_result["step_id"] == "upgrade"
+    result = await hass.config_entries.flow.async_configure(
+        init_result["flow_id"], USER_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    # USER_INPUT turns both of these on.
+    assert entry.options[CONF_SCRYPTED_NVR] is True
+    assert entry.options[CONF_AUTO_REGISTER_RESOURCES] is True
+    # Untouched by this form.
+    assert entry.options[CONF_ENABLE_ENTITIES] is False
+    assert entry.options["device_types"] == ["Camera", "Doorbell", "Sensor"]

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,7 +1,7 @@
 """Tests for ScryptedClient."""
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -109,3 +109,26 @@ async def test_disconnect_triggers_reconnect(hass, entry, fake_sdk, mock_connect
     # disconnect handler is a no-op once closing
     mock_connect_sdk.transport.handlers["disconnect"]()
     assert client.connected is False
+
+
+async def test_reconnect_survives_unexpected_error(hass, entry, fake_sdk):
+    """An unexpected reconnect error is logged and retried, not fatal."""
+    client = ScryptedClient(hass, entry)
+    await client.async_connect()
+
+    attempts = []
+
+    async def _connect():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("boom")
+        client.connected = True
+
+    with (
+        patch.object(client, "async_connect", _connect),
+        patch("custom_components.scrypted.hub.asyncio.sleep", AsyncMock()),
+    ):
+        client.connected = False
+        await client._reconnect_loop()
+
+    assert len(attempts) == 2

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -742,3 +742,37 @@ async def test_remove_config_entry_device_entities_disabled(
         },
     )
     assert await scrypted.async_remove_config_entry_device(hass, entry, device_entry)
+
+
+async def test_failed_connect_does_not_publish_token(hass, mock_forward_entry_setups):
+    """A setup that cannot connect leaves no token mapping behind."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: EXAMPLE_HOST,
+            CONF_ICON: "mdi:test",
+            CONF_NAME: "Scrypted",
+            CONF_USERNAME: "user",
+        },
+        options={
+            CONF_AUTO_REGISTER_RESOURCES: False,
+            CONF_SCRYPTED_NVR: False,
+            CONF_ENABLE_ENTITIES: True,
+            "device_types": ["Camera", "Doorbell"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(
+            scrypted.ScryptedClient,
+            "async_connect",
+            AsyncMock(side_effect=ScryptedConnectionError("nope")),
+        ),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await scrypted.async_setup_entry(hass, entry)
+
+    # The proxy view resolves entries through hass.data; a token left there
+    # would keep serving an entry that never loaded.
+    assert not hass.data.get(DOMAIN)


### PR DESCRIPTION
## Summary

Three config entry lifecycle bugs found while reviewing the device-entities series.

**Reauth silently reset the user's options.** The reauth handler passed `options={}` to `async_update_entry`, discarding everything its form does not collect. Re-entering a password reset the device-type allowlist and the enable-entities flag to defaults:

```
before reauth:  device_types=['Camera', 'Doorbell', 'Sensor']
after  reauth:  device_types=['Camera', 'Doorbell']
```

Every entity for the dropped types disappeared on the following reload, with nothing pointing at the password change as the cause. Options are now carried through, and the two fields the upgrade form does collect still take precedence.

**A failed setup left a live token behind.** The token was published into `hass.data` before the engine.io connect that raises `ConfigEntryNotReady`. The proxy view and the token sensor resolve entries through that mapping, and a failed setup never reaches `async_unload_entry`, so an entry stuck in `SETUP_RETRY` kept serving proxied requests using its credentials. If a later retry returned a different token, both mapped to the same entry and unload only removed one. The mapping is now published once setup can no longer fail.

**The reconnect loop could die permanently.** It caught only `ScryptedConnectionError`. Anything else, such as a closed session during shutdown or a non-JSON login response, ended the background task, and since no further disconnect event fires there was nothing to restart it. Entities stayed unavailable until the entry was reloaded by hand. Unexpected errors are now logged and retried on the same backoff.

## Test plan

- [x] `pytest` — 176 tests, 100% coverage gate
- [x] Three new regression tests, each failing before its fix
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
