### PR TITLE
fix: give the engine.io transport a session it can close

### DIFF
--- a/custom_components/scrypted/sdk.py
+++ b/custom_components/scrypted/sdk.py
@@ -3,11 +3,13 @@
 The transport, login flow, and plugin-remote handshake live in the published
 scrypted-sdk package; this module only wires HA-managed aiohttp sessions into
 it. It is intentionally thin and I/O-bound; it is excluded from unit test
-coverage (see .coveragerc) and verified end-to-end with scripts/dev_connect.py.
+coverage (see pyproject.toml) and verified end-to-end with
+scripts/dev_connect.py.
 """
 
 from __future__ import annotations
 
+import aiohttp
 from scrypted_sdk import (
     EioRpcTransport,
     ScryptedConnectionError,
@@ -16,10 +18,10 @@ from scrypted_sdk import (
 )
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import (
-    async_create_clientsession,
-    async_get_clientsession,
-)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import client_context_no_verify
+
+from .const import DEFAULT_SCRYPTED_PORT
 
 __all__ = ["async_connect_sdk", "get_base_url"]
 
@@ -32,7 +34,7 @@ def get_base_url(host: str) -> str:
     if len(ipport) > 2:
         raise ScryptedConnectionError(f"invalid Scrypted host: {host}")
     ip = ipport[0]
-    port = ipport[1] if len(ipport) == 2 else "10443"
+    port = ipport[1] if len(ipport) == 2 else DEFAULT_SCRYPTED_PORT
     return f"https://{ip}:{port}"
 
 
@@ -45,13 +47,18 @@ async def async_connect_sdk(
 ) -> tuple[EioRpcTransport, ScryptedStatic]:
     """Login and establish the engine.io RPC session. Returns (transport, sdk).
 
-    HA's client sessions carry a cached no-verify SSL context, which keeps the
-    blocking ssl.create_default_context call off the event loop. Login uses
-    HA's shared session (the SDK leaves caller-provided login sessions open);
-    the transport owns a dedicated session that transport.close() tears down.
+    Login uses HA's shared session, which the SDK leaves open for its owner.
+    The transport instead gets a plain session it can genuinely close: HA
+    replaces close() on its own sessions with a no-op that only logs, so a
+    transport built on one would leak a session per reconnect. The SSL context
+    is HA's cached no-verify context, which keeps the blocking
+    ssl.create_default_context call off the event loop.
     """
     transport = EioRpcTransport(
-        hass.loop, http_session=async_create_clientsession(hass, verify_ssl=False)
+        hass.loop,
+        http_session=aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(ssl=client_context_no_verify())
+        ),
     )
     try:
         return await connect_scrypted_client(

--- a/custom_components/scrypted/translations/en.json
+++ b/custom_components/scrypted/translations/en.json
@@ -26,7 +26,7 @@
           "password": "Password",
           "username": "Username",
           "scrypted_nvr": "Replace Scrypted Management Console sidebar with Scrypted NVR sidebar. Requires Scrypted NVR.",
-          "auto_register_resources": "Automatically register Lovelace resources for the Scrypted NVR cards. Recommended if you use Scrypted NVR."
+          "auto_register_resources": "Automatically register Lovelace resources for the Scrypted NVR cards. Requires Scrypted NVR and recommended if so."
         },
         "description": "Once you enter your credentials, your config entry will now automatically set up a panel for you in the UI with the specified name and icon. Once this is complete, you can remove the `panel_iframe` in your configuration.yaml if you created one for this entry. If your credentials don't work, validate that the server host is an HTTPS endpoint and that your credentials are correct."
       },
@@ -38,7 +38,7 @@
           "password": "Password",
           "username": "Username",
           "scrypted_nvr": "Replace Scrypted Management Console sidebar with Scrypted NVR sidebar. Requires Scrypted NVR.",
-          "auto_register_resources": "Automatically register Lovelace resources for the Scrypted NVR cards. Recommended if you use Scrypted NVR."
+          "auto_register_resources": "Automatically register Lovelace resources for the Scrypted NVR cards. Requires Scrypted NVR and recommended if so."
         },
         "description": "Enter your Scrypted server details (you must use an HTTPS endpoint) as well as a name and icon to use for the new panel on the UI.\n\nHost examples:\n- `192.168.1.124`\n- `192.168.1.124:10443`"
       }


### PR DESCRIPTION
## Summary

**The transport could never close its session.** `async_connect_sdk` handed `EioRpcTransport` a session from `async_create_clientsession`, but Home Assistant wraps `close()` on its own sessions with a reporting stub:

```python
clientsession.close = warn_use(clientsession.close, WARN_CLOSE_MSG)
```

`warn_use` returns a function that only calls `report_usage()` and never invokes the original, so `transport.close()`'s `await self._http_session.close()` was a no-op. The docstring claiming the transport "owns a dedicated session that transport.close() tears down" was simply not true, and every reconnect built another session that survived until the entry unloaded.

The transport now gets a plain `aiohttp.ClientSession` whose `close()` works, using HA's `client_context_no_verify()` for SSL. That context is `@cache`d and pre-warmed at import, so the blocking `create_default_context` call still stays off the event loop, which was the original reason for going through HA's helper. Login continues to use HA's shared session, which the SDK deliberately leaves open for its owner.

**Two smaller drifts from the same review:**

- `get_base_url` repeated `"10443"` as a literal while `DEFAULT_SCRYPTED_PORT` already existed and was used by the proxy's copy of the same parsing.
- `translations/en.json` still carried the pre-edit wording for the auto-register option. Home Assistant loads that file for custom integrations, not `strings.json`, so the reworded description never reached users.

The module docstring also pointed at `.coveragerc` for the coverage exclusion, which moved into `pyproject.toml` when that file was removed.

## Test plan

- [x] `pytest` — 175 tests, 100% coverage gate
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit
- [x] `sdk.py` is coverage-excluded and exercised by `scripts/dev_connect.py` against a live server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
