### PR TITLE
fix: keep a way out of the panel when ha-menu-button hides itself

### DIFF
--- a/custom_components/scrypted/entrypoint.js
+++ b/custom_components/scrypted/entrypoint.js
@@ -4,6 +4,10 @@ import {
     css,
 } from "./lit-core.min.js";
 
+// mdi:menu. Inlined so the toggle never depends on another element being
+// registered by the time this panel loads.
+const MENU_ICON_PATH = "M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z";
+
 class ExamplePanel extends LitElement {
     static get properties() {
         return {
@@ -16,12 +20,19 @@ class ExamplePanel extends LitElement {
     render() {
         return html`
         <div style="height: 100%; display: flex; flex-direction: column;">
-            <div style="display: flex; align-items: center;">
-                <ha-menu-button
-                slot="navigationIcon"
-                .hass=${this.hass}
-                .narrow=${this.narrow}
-                ></ha-menu-button>
+            <div class="toolbar">
+                ${this._showMenuButton ? html`
+                    <button
+                        class="menu"
+                        aria-label="Toggle menu"
+                        title="Toggle menu"
+                        @click=${this._toggleMenu}
+                    >
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="${MENU_ICON_PATH}"></path>
+                        </svg>
+                    </button>
+                ` : ""}
                 ${this.narrow ? html`
                     <div>Home Assistant: Scrypted</div>
                 ` : ""}
@@ -35,6 +46,25 @@ class ExamplePanel extends LitElement {
             </div>
         </div>
     `;
+    }
+
+    get _showMenuButton() {
+        /* ha-menu-button decides this from Lit context rather than from the
+           properties it is given, and renders nothing when that context is
+           missing. On a phone the sidebar is hidden, so losing the button
+           leaves no way out of the panel short of force-quitting the app.
+           Same rule, but read from what Home Assistant hands this panel. */
+        return this.narrow || this.hass?.dockedSidebar === "always_hidden";
+    }
+
+    _toggleMenu() {
+        /* What ha-menu-button fires. composed so it leaves this shadow root. */
+        this.dispatchEvent(
+            new CustomEvent("hass-toggle-menu", {
+                bubbles: true,
+                composed: true,
+            })
+        );
     }
 
     static get styles() {
@@ -65,6 +95,24 @@ class ExamplePanel extends LitElement {
                 --safe-area-content-inset-right,
                 var(--safe-area-inset-right, 0px)
             );
+        }
+        .toolbar {
+            display: flex;
+            align-items: center;
+        }
+        .menu {
+            display: flex;
+            padding: 12px;
+            border: 0;
+            background: none;
+            color: var(--primary-text-color);
+            cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
+        }
+        .menu svg {
+            width: 24px;
+            height: 24px;
+            fill: currentColor;
         }
         iframe {
             border: 0;


### PR DESCRIPTION
## Summary

Follow-up to #65, from the same [r/Scrypted thread](https://www.reddit.com/r/Scrypted/comments/1wdma05/home_assistant_scrypted_addon_borked_after_update/). The reporter: *"I periodically lose the hamburger menu and have to force close to get back to my HA dashboard."*

On a phone the sidebar is hidden, so that hamburger is the only way out of this panel. When it goes, the app has to be killed.

`ha-menu-button` decides whether to draw from `_narrow` and `_ui`, which it takes from Lit context rather than from the properties it is given, and it renders nothing at all when that context is unavailable:

```js
render() { if (!this._show || !this._ui) return nothing; }
this._show = (kioskMode === false && (narrow || dockedSidebar === "always_hidden")) || alwaysVisible
```

The `.hass` and `.narrow` this panel passes it therefore have no bearing on whether it appears. There's also no lever to force it: `_alwaysVisible` would, but it's internal and never exposed as an attribute.

So the toggle is now a plain button with an inlined `mdi:menu` path that fires the same `hass-toggle-menu` event, bubbling and composed so it escapes the shadow root. It depends on no other custom element having been registered by the time the panel module loads, and on no context being reachable. Visibility uses HA's own rule, read from the `narrow` and `hass.dockedSidebar` this panel is handed directly, so a desktop with a docked sidebar still gets no redundant hamburger.

## Trade-off

This loses the unread-notification dot `ha-menu-button` draws. Being unable to leave the panel without force-quitting seemed clearly the worse of the two, but happy to revisit if you'd rather keep the dot and accept the dependency.

## Verification

- [x] `pytest` — 182 tests, 100% coverage gate (HA 2026.9.2)
- [x] `ruff check` / `ruff format --check`, mypy via pre-commit
- [x] Panel module syntax-checked as an ES module
- [x] Visibility rule exercised across narrow, docked, `always_hidden` and missing-`hass` states
- [x] Deployed to a live HA instance; loads clean, no errors
- [ ] **Whether this cures the reporter's disappearing hamburger is unconfirmed.** It guarantees an exit regardless of cause, but I could not reproduce the disappearance itself, so I can't say which of the two candidate causes was at work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
