### PR TITLE
ci: syntax-check the panel's browser JavaScript

### DIFF
--- a/.github/workflows/panel.yaml
+++ b/.github/workflows/panel.yaml
@@ -1,0 +1,35 @@
+---
+name: Panel JavaScript
+
+# The Python lint workflow filters on **.py, so changes to the panel's browser
+# JavaScript would otherwise run no check at all.
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [main]
+    paths:
+      - "custom_components/scrypted/**.js"
+      - "custom_components/scrypted/**.html"
+      - "scripts/check_panel_js.mjs"
+      - ".github/workflows/panel.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "custom_components/scrypted/**.js"
+      - "custom_components/scrypted/**.html"
+      - "scripts/check_panel_js.mjs"
+      - ".github/workflows/panel.yaml"
+
+jobs:
+  syntax:
+    name: Panel JavaScript syntax
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Syntax-check panel JavaScript
+        run: node scripts/check_panel_js.mjs

--- a/README.md
+++ b/README.md
@@ -84,4 +84,7 @@ pytest
 # Run linting and formatting checks
 ruff check .
 ruff format --check .
+
+# Syntax-check the panel's browser JavaScript (requires Node)
+node scripts/check_panel_js.mjs
 ```

--- a/scripts/check_panel_js.mjs
+++ b/scripts/check_panel_js.mjs
@@ -1,0 +1,90 @@
+/**
+ * Syntax-check the panel's browser JavaScript without executing it.
+ *
+ * The Python lint and test workflows never look at these files, so a syntax
+ * error in the panel passes every check and only fails in the browser, where
+ * it leaves an empty sidebar panel. This parses:
+ *
+ *   - every .js file in custom_components/scrypted as an ES module
+ *   - every inline <script> in its .html files, as a module or classic script
+ *     according to its type attribute
+ *
+ * Usage: node scripts/check_panel_js.mjs
+ */
+
+import { spawnSync } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+// Resolve paths from the repository root so the script works from any cwd.
+process.chdir(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const PANEL_DIR = "custom_components/scrypted";
+
+/** Return null when `source` parses as an ES module, else the error text. */
+function moduleError(source) {
+  // Without --input-type=module node parses stdin as CommonJS and rejects
+  // import/export even in a valid module. The flag is only honoured for
+  // source on stdin, not for a file path, hence spawning rather than
+  // pointing node at the file.
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--check"],
+    { input: source, encoding: "utf8" },
+  );
+  return result.status === 0 ? null : result.stderr.trim();
+}
+
+/** Return null when `source` parses as a classic script, else the error text. */
+function scriptError(source, label) {
+  try {
+    // Compiling a vm.Script parses the code; nothing runs until it is invoked.
+    new vm.Script(source, { filename: label });
+    return null;
+  } catch (error) {
+    return String(error.stack ?? error).trim();
+  }
+}
+
+const results = [];
+
+for (const name of (await readdir(PANEL_DIR)).sort()) {
+  const file = path.posix.join(PANEL_DIR, name);
+
+  if (name.endsWith(".js")) {
+    results.push([file, moduleError(await readFile(file, "utf8"))]);
+  } else if (name.endsWith(".html")) {
+    const html = await readFile(file, "utf8");
+    const blocks = html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi);
+    let index = 0;
+    for (const [, attributes, body] of blocks) {
+      index += 1;
+      const label = `${file} <script> #${index}`;
+      const isModule = /\btype\s*=\s*["']?module\b/i.test(attributes);
+      results.push([
+        label,
+        isModule ? moduleError(body) : scriptError(body, label),
+      ]);
+    }
+  }
+}
+
+const failures = results.filter(([, error]) => error);
+for (const [label, error] of results) {
+  if (error) {
+    console.error(`FAIL ${label}\n${error}\n`);
+  } else {
+    console.log(`ok   ${label}`);
+  }
+}
+
+if (results.length === 0) {
+  console.error(`No panel JavaScript found under ${PANEL_DIR}.`);
+  process.exit(1);
+}
+if (failures.length) {
+  console.error(`${failures.length} of ${results.length} failed to parse.`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Nothing in CI looked at the panel's JavaScript. The Lint workflow filters on `**.py`, and the test suite replaces the panel files with stub strings, so a syntax error in `entrypoint.js` or in the inline script in `entrypoint.html` would pass every check and only fail in the browser, as an empty sidebar panel. #66 is a live example: it changes only `entrypoint.js`, and Lint did not run on it at all.

This adds `scripts/check_panel_js.mjs` and a workflow that runs it whenever panel files change. The script:

- parses every `.js` file in `custom_components/scrypted` as an ES module
- parses every inline `<script>` in the panel's `.html` files, as a module or classic script according to its `type` attribute
- compiles only, never executes

Two details worth knowing:

- **Modules need `--input-type=module`.** Without it node treats the source as CommonJS and rejects `import`/`export` even in a valid module, so a naive `node --check entrypoint.js` fails on correct code. The flag is only honoured for source on stdin, so each file is fed through stdin rather than passed as a path.
- **It fails when it finds nothing.** If the panel directory ever moves, the check errors out instead of quietly checking zero files and passing.

It's a separate workflow rather than a wider filter on Lint, which would otherwise run ruff on JavaScript-only changes to no purpose. The only `run:` step is a fixed command with no expression interpolation, and it triggers on `pull_request` rather than `pull_request_target`.

The README's local development commands gain the same invocation.

## Verification

Run locally against each failure mode:

| Case | Result |
|---|---|
| Clean tree, from repo root | pass |
| Clean tree, from another directory | pass |
| Syntax error in `entrypoint.js` | fail, reports the file and error |
| Syntax error in `entrypoint.html` inline script | fail, reports the script block |
| Corrupted `lit-core.min.js` | fail |
| No panel files present | fail |
| #66's `entrypoint.js` | pass |

The last row means merge order between this and #66 doesn't matter.

- [x] `yamllint`, `check-yaml`, `markdownlint` and the rest of pre-commit
- [x] `pytest` — 182 tests, unaffected
- [ ] `actionlint` not run locally (its pre-commit hook can't build here). This PR changes the workflow and the script, so the new check runs on it and will show whether the workflow is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
